### PR TITLE
fix: 로고 클릭시 모집 마감 안보기 토글 버튼이 상이하게 동작하는 이슈를 수정하라

### DIFF
--- a/src/components/common/HeaderWrapper.test.tsx
+++ b/src/components/common/HeaderWrapper.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { groupsConditionState } from '@/recoil/group/atom';
 import palette from '@/styles/palette';
@@ -7,17 +7,19 @@ import RecoilObserver from '@/test/RecoilObserver';
 
 import HeaderWrapper from './HeaderWrapper';
 
+jest.mock('next/link', () => ({ children }: any) => children);
+
 describe('HeaderWrapper', () => {
-  const handleReset = jest.fn();
+  const handleChange = jest.fn();
 
   beforeEach(() => {
-    handleReset.mockClear();
+    handleChange.mockClear();
   });
 
   const renderHeaderWrapper = () => render((
     <InjectTestingRecoilState>
       <>
-        <RecoilObserver node={groupsConditionState} onChange={handleReset} />
+        <RecoilObserver node={groupsConditionState} onChange={handleChange} />
         <HeaderWrapper
           hasBackground={given.hasBackground}
           isScrollTop={given.isScrollTop}
@@ -26,6 +28,20 @@ describe('HeaderWrapper', () => {
       </>
     </InjectTestingRecoilState>
   ));
+
+  describe('로고를 클릭한다', () => {
+    it('프로젝트 스터디 목록 필터 state가 변경되는 이벤트가 호출되어야만 한다', () => {
+      renderHeaderWrapper();
+
+      fireEvent.click(screen.getByTestId('logo-icon'));
+
+      expect(handleChange).toBeCalledWith({
+        isFilterCompleted: false,
+        category: ['study', 'project'],
+        tag: '',
+      });
+    });
+  });
 
   context('hasBackground가 true인 경우', () => {
     given('hasBackground', () => true);

--- a/src/components/common/HeaderWrapper.tsx
+++ b/src/components/common/HeaderWrapper.tsx
@@ -2,7 +2,7 @@ import React, { memo, PropsWithChildren, ReactElement } from 'react';
 
 import styled from '@emotion/styled';
 import Link from 'next/link';
-import { useResetRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 
 import { groupsConditionState } from '@/recoil/group/atom';
 import Layout from '@/styles/Layout';
@@ -21,7 +21,13 @@ interface Props {
 function HeaderWrapper({
   hasBackground, isScrollTop, testId, children,
 }: PropsWithChildren<Props>):ReactElement {
-  const resetGroupsCondition = useResetRecoilState(groupsConditionState);
+  const setGroupsCondition = useSetRecoilState(groupsConditionState);
+
+  const onClickLogo = () => setGroupsCondition((prev) => ({
+    ...prev,
+    category: ['study', 'project'],
+    tag: '',
+  }));
 
   return (
     <>
@@ -29,7 +35,7 @@ function HeaderWrapper({
         <HeaderContents>
           <Link href="/" passHref>
             <a>
-              <LogoIcon onClick={resetGroupsCondition} />
+              <LogoIcon onClick={onClickLogo} data-testid="logo-icon" />
             </a>
           </Link>
           {children}


### PR DESCRIPTION
- 로고 클릭시 모집 마감 안보기 토글 버튼이 반대로 동작하는 이슈를 수정
  - 로고 클릭시 모집 마감 안보기 토글 state도 리셋 시켜서 발생 => isFilterCompleted state는 초기화시키지 않도록 수정