### PR TITLE
style: sign up 페이지에 반응형을 적용하라

### DIFF
--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -9,6 +9,7 @@ import * as yup from 'yup';
 
 import type { SignUpAdditionalForm } from '@/models/auth';
 import { Position, positionOption } from '@/models/group';
+import mq from '@/styles/responsive';
 import { stringToExcludeNull } from '@/utils/utils';
 
 import Button from '../common/Button';
@@ -83,7 +84,9 @@ function SignUpForm({ onSubmit, fields }: Props): ReactElement {
         onClear={() => setValue('portfolioUrl', '')}
         type="url"
       />
-      <Button type="submit" color="success" size="large">확인</Button>
+      <SubmitButton type="submit" color="success" size="large" disabled={!position}>
+        확인
+      </SubmitButton>
     </SignUpFormWrapper>
   );
 }
@@ -91,9 +94,17 @@ function SignUpForm({ onSubmit, fields }: Props): ReactElement {
 export default SignUpForm;
 
 const SignUpFormWrapper = styled.form`
+  position: relative;
   width: 100%;
 
   & > :not(:last-child) {
     margin-bottom: 20px;
   }
+`;
+
+const SubmitButton = styled(Button)`
+  ${mq({
+    position: ['fixed', 'initial'],
+    bottom: ['20px', 'initial'],
+  })};
 `;

--- a/src/components/common/CreatableSelectBox.tsx
+++ b/src/components/common/CreatableSelectBox.tsx
@@ -171,6 +171,13 @@ const StyledSelect = styled(CreatableSelect)<{ size: Size; isError: boolean; }>`
     box-shadow: none;
   }
 
+  & .select__control--is-focused:hover {
+    ${({ isError, theme }) => !isError && css`
+      border-color: ${theme.success};
+    `}
+    box-shadow: none;
+  }
+
   & .select__option {
     cursor: pointer;
     color: ${({ theme }) => theme.foreground};
@@ -185,6 +192,10 @@ const StyledSelect = styled(CreatableSelect)<{ size: Size; isError: boolean; }>`
 
   & .select__menu {
     border-radius: 8px;
+  }
+
+  & .select__option:active {
+    background-color: ${({ theme }) => theme.accent2} !important;
   }
 
   & .select__option--is-focused {

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -75,7 +75,7 @@ function Header({
         />
       ) : (
         <Button
-          color="success"
+          color="primary"
           size="small"
           type="button"
           onClick={onClick}

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -127,12 +127,16 @@ const InputField = styled.input<{ isError?: boolean; hasValue: boolean; }>`
   }
 
   &:disabled {
-    color: ${({ theme }) => theme.accent6};
+    opacity: 1;
+    -webkit-text-fill-color: ${({ theme }) => theme.accent5};
+    color: ${({ theme }) => theme.accent5};
     background: ${({ theme }) => theme.accent1};
   }
 
   &:read-only {
-    color: ${({ theme }) => theme.accent6};
+    opacity: 1;
+    -webkit-text-fill-color: ${({ theme }) => theme.accent5};
+    color: ${({ theme }) => theme.accent5};
     background: ${({ theme }) => theme.accent1};
   }
 


### PR DESCRIPTION
- ios 모바일에서 input에 disabled시 text색상이 opacity가 자동으로 걸려 흐릿하게 보이는 이슈 수정
- 시작하기 버튼 primary 색상으로 변경
- 모바일 시 sign up 페이지 submit 버튼 위치 bottom fixed로 변경
- create select box hover 및 active 시 기본으로 적용되어있는 css 제거