### PR TITLE
fix: 댓글이 순서 및 댓글 삭제, 추가시 댓글 개수가 변하지 않는 이슈를 수정하라

### DIFF
--- a/src/containers/detail/CommentsContainer.tsx
+++ b/src/containers/detail/CommentsContainer.tsx
@@ -16,15 +16,17 @@ import { h4Font } from '@/styles/fontStyles';
 import { checkNumNull } from '@/utils/utils';
 
 function CommentsContainer(): ReactElement {
+  const perPage = 15;
+
   const router = useRouter();
   const { id: groupId } = router.query as GroupQuery;
   const { data: user } = useFetchUserProfile();
   const { data: commentCount } = useFetchCommentCount(groupId);
   const { query, refState } = useInfiniteFetchComments({
-    perPage: 15,
+    perPage,
   });
-  const { mutate: addCommentMutate } = useAddComment();
-  const { mutate: deleteCommentMutate } = useDeleteComment();
+  const { mutate: addCommentMutate } = useAddComment(perPage);
+  const { mutate: deleteCommentMutate } = useDeleteComment(perPage);
 
   const onSubmit = useCallback((commentForm: CommentFields) => addCommentMutate({
     ...commentForm,

--- a/src/hooks/api/comment/queryDataUtils/index.test.ts
+++ b/src/hooks/api/comment/queryDataUtils/index.test.ts
@@ -1,0 +1,66 @@
+import FIXTURE_COMMENT from '../../../../../fixtures/comment';
+import FIXTURE_PROFILE from '../../../../../fixtures/profile';
+
+import { addCommentQueryData, deleteCommentQueryData } from '.';
+
+describe('addCommentQueryData', () => {
+  const commentId = 'commentId';
+  const commentForm = {
+    content: 'content',
+    groupId: 'groupId',
+    writer: FIXTURE_PROFILE,
+  };
+
+  const newComments = addCommentQueryData(commentId, commentForm);
+
+  it('pages.items의 첫번째 인덱스에 새로운 comment item이 추가되어야만 한다', () => {
+    const result = newComments({
+      pageParams: [],
+      pages: [{
+        items: [FIXTURE_COMMENT],
+      }, {
+        items: [FIXTURE_COMMENT],
+      }],
+    });
+
+    expect(result.pages).toEqual([{
+      items: [
+        {
+          commentId,
+          ...commentForm,
+          createdAt: new Date().toString(),
+        },
+        FIXTURE_COMMENT,
+      ],
+    }, {
+      items: [FIXTURE_COMMENT],
+    }]);
+  });
+});
+
+describe('deleteCommentQueryData', () => {
+  const { commentId } = FIXTURE_COMMENT;
+  const mockComment = {
+    ...FIXTURE_COMMENT,
+    commentId: '2',
+  };
+
+  const newComments = deleteCommentQueryData(commentId);
+
+  it(`${commentId}를 가진 아이템이 삭제된 후 반환되어야만 한다`, () => {
+    const result = newComments({
+      pageParams: [],
+      pages: [{
+        items: [FIXTURE_COMMENT, mockComment],
+      }, {
+        items: [mockComment],
+      }],
+    });
+
+    expect(result.pages).toEqual([{
+      items: [mockComment],
+    }, {
+      items: [mockComment],
+    }]);
+  });
+});

--- a/src/hooks/api/comment/queryDataUtils/index.ts
+++ b/src/hooks/api/comment/queryDataUtils/index.ts
@@ -1,0 +1,51 @@
+import { InfiniteData } from 'react-query';
+
+import { InfiniteResponse } from '@/models';
+import { Comment, CommentForm } from '@/models/group';
+import { checkEmpty } from '@/utils/utils';
+
+export const addCommentQueryData = (commentId: string, commentForm: CommentForm) => (
+  comments?: InfiniteData<InfiniteResponse<Comment>>,
+) => {
+  const newPages = comments?.pages.reduce((prev: InfiniteResponse<Comment>[], cur, index) => {
+    if (index === 0) {
+      return [
+        ...prev,
+        {
+          ...cur,
+          items: [{
+            ...commentForm,
+            commentId,
+            createdAt: new Date().toString(),
+          },
+          ...cur.items,
+          ],
+        },
+      ];
+    }
+
+    return [
+      ...prev,
+      cur,
+    ];
+  }, []);
+
+  return {
+    pageParams: checkEmpty(comments?.pageParams),
+    pages: checkEmpty(newPages),
+  };
+};
+
+export const deleteCommentQueryData = (commentId: string) => (
+  comments?: InfiniteData<InfiniteResponse<Comment>>,
+) => {
+  const newPages = comments?.pages.map((page) => ({
+    ...page,
+    items: page.items.filter((item) => item.commentId !== commentId),
+  }));
+
+  return {
+    pageParams: checkEmpty(comments?.pageParams),
+    pages: checkEmpty(newPages),
+  };
+};

--- a/src/hooks/api/comment/useAddComment.test.ts
+++ b/src/hooks/api/comment/useAddComment.test.ts
@@ -10,7 +10,7 @@ import useAddComment from './useAddComment';
 jest.mock('@/services/api/comment');
 
 describe('useAddComment', () => {
-  const useAddCommentHook = () => renderHook(() => useAddComment(), { wrapper });
+  const useAddCommentHook = () => renderHook(() => useAddComment(15), { wrapper });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -30,5 +30,6 @@ describe('useAddComment', () => {
     });
 
     expect(result.current.data).toBe('commentId');
+    expect(postGroupComment).toBeCalled();
   });
 });

--- a/src/hooks/api/comment/useDeleteComment.test.ts
+++ b/src/hooks/api/comment/useDeleteComment.test.ts
@@ -9,7 +9,7 @@ jest.mock('@/services/api/comment');
 jest.mock('@/hooks/useRenderSuccessToast');
 
 describe('useDeleteComment', () => {
-  const useDeleteCommentHook = () => renderHook(() => useDeleteComment(), { wrapper });
+  const useDeleteCommentHook = () => renderHook(() => useDeleteComment(15), { wrapper });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -28,5 +28,6 @@ describe('useDeleteComment', () => {
     });
 
     expect(result.current.isSuccess).toBeTruthy();
+    expect(deleteGroupComment).toBeCalled();
   });
 });

--- a/src/services/api/comment.ts
+++ b/src/services/api/comment.ts
@@ -37,7 +37,7 @@ export const getGroupComments = async (groupId: string, {
   const commentRef = collectionRef(COMMENTS);
   const commonQueries = [
     where('groupId', '==', groupId),
-    orderBy('createdAt', 'asc'),
+    orderBy('createdAt', 'desc'),
   ];
 
   if (!lastUid) {


### PR DESCRIPTION
- 댓글이 최신순으로 나타나도록 수정
- 댓글 추가 및 삭제시 refresh 전에는 개수가 변하지 않는 이슈를 수정
- 댓글 추가 및 삭제시 invalidateQueries를 사용하여 api를 호출하는 로직을 setQueryData를 사용하여 api를 호출하지 않고 댓글 상태가 변하도록 수정