### PR TITLE
fix: infinite scroll이 적용되어있는 리스트부분에서 불필요한 호출이 발생하는 이슈를 수정하라

### DIFF
--- a/src/components/myInfo/MyGroup.test.tsx
+++ b/src/components/myInfo/MyGroup.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { lightTheme } from '@/styles/theme';
 import MockTheme from '@/test/MockTheme';
@@ -9,12 +9,9 @@ import FIXTURE_GROUP from '../../../fixtures/group';
 import MyGroup from './MyGroup';
 
 describe('MyGroup', () => {
-  const handleClick = jest.fn();
-
   const renderMyGroup = () => render((
     <MockTheme>
       <MyGroup
-        onClick={handleClick}
         group={given.group}
       />
     </MockTheme>
@@ -60,18 +57,6 @@ describe('MyGroup', () => {
       const { container } = renderMyGroup();
 
       expect(container).toHaveTextContent(/2명 신청 중/);
-    });
-  });
-
-  describe('group을 클릭한다', () => {
-    given('group', () => (FIXTURE_GROUP));
-
-    it('클릭 이벤트가 호출되어야만 한다', () => {
-      renderMyGroup();
-
-      fireEvent.click(screen.getByText(FIXTURE_GROUP.title));
-
-      expect(handleClick).toBeCalledWith(FIXTURE_GROUP.groupId);
     });
   });
 

--- a/src/components/myInfo/MyGroup.tsx
+++ b/src/components/myInfo/MyGroup.tsx
@@ -5,6 +5,7 @@ import React, {
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import dayjs from 'dayjs';
+import Link from 'next/link';
 
 import useCurrentTime from '@/hooks/useCurrentTime';
 import useGroupRecruitmentStatus from '@/hooks/useGroupRecruitmentStatus';
@@ -17,10 +18,9 @@ import { removeAllHtml } from '@/utils/filter';
 
 interface Props {
   group: Group;
-  onClick: (groupId: string) => void;
 }
 
-function MyGroup({ group, onClick }: Props, ref: ForwardedRef<HTMLDivElement>): ReactElement {
+function MyGroup({ group }: Props, ref: ForwardedRef<HTMLAnchorElement>): ReactElement {
   const {
     title, content, createdAt, groupId, numberApplicants,
     recruitmentEndDate, isCompleted, thumbnail, shortDescription,
@@ -43,39 +43,39 @@ function MyGroup({ group, onClick }: Props, ref: ForwardedRef<HTMLDivElement>): 
   const dateStatus = recruitStatus(`${dayjs(currentTime).to(dayjs(recruitmentEndDate))} 마감`)[status];
 
   return (
-    <MyGroupWrapper
-      role="listitem"
-      onClick={() => onClick(groupId)}
-      tabIndex={0}
-      ref={ref}
-    >
-      <div>
-        <MyGroupContents>
-          <div className="group-title">{title}</div>
-          <div className="group-content">
-            {shortDescription || removeAllHtml(content)}
-          </div>
-        </MyGroupContents>
-        <GroupMetaData status={status}>
-          <div className="date-status" data-testid="date-status">{dateStatus}</div>
-          <Divider />
-          <div className="number-applied">{numberApplied}</div>
-          <Divider />
-          <div>{dayjs(createdAt).format('YYYY년 MM월 DD일')}</div>
-        </GroupMetaData>
-      </div>
-      {thumbnail && (
-        <ThumbnailWrapper>
-          <Thumbnail src={thumbnail} alt="thumbnail" />
-        </ThumbnailWrapper>
-      )}
-    </MyGroupWrapper>
+    <Link href={`/detail/${groupId}`} passHref>
+      <MyGroupWrapper
+        role="listitem"
+        ref={ref}
+      >
+        <div>
+          <MyGroupContents>
+            <div className="group-title">{title}</div>
+            <div className="group-content">
+              {shortDescription || removeAllHtml(content)}
+            </div>
+          </MyGroupContents>
+          <GroupMetaData status={status}>
+            <div className="date-status" data-testid="date-status">{dateStatus}</div>
+            <Divider />
+            <div className="number-applied">{numberApplied}</div>
+            <Divider />
+            <div>{dayjs(createdAt).format('YYYY년 MM월 DD일')}</div>
+          </GroupMetaData>
+        </div>
+        {thumbnail && (
+          <ThumbnailWrapper>
+            <Thumbnail src={thumbnail} alt="thumbnail" />
+          </ThumbnailWrapper>
+        )}
+      </MyGroupWrapper>
+    </Link>
   );
 }
 
-export default memo(forwardRef<HTMLDivElement, Props>(MyGroup));
+export default memo(forwardRef<HTMLAnchorElement, Props>(MyGroup));
 
-const MyGroupWrapper = styled.div`
+const MyGroupWrapper = styled.a`
   cursor: pointer;
   outline: none;
   display: flex;

--- a/src/components/myInfo/MyGroups.test.tsx
+++ b/src/components/myInfo/MyGroups.test.tsx
@@ -5,14 +5,12 @@ import FIXTURE_GROUP from '../../../fixtures/group';
 import MyGroups from './MyGroups';
 
 describe('MyGroups', () => {
-  const handleClick = jest.fn();
   const lastItemRef = jest.fn();
 
   const MockComponent = () => <>Component</>;
 
   const renderMyGroups = () => render((
     <MyGroups
-      onClickGroup={handleClick}
       groups={given.groups}
       refState={{
         lastItemRef,

--- a/src/components/myInfo/MyGroups.tsx
+++ b/src/components/myInfo/MyGroups.tsx
@@ -9,13 +9,12 @@ import MyGroupsSkeletonLoader, { MyGroupLayout } from './MyGroupsSkeletonLoader'
 
 interface Props {
   groups: InfiniteResponse<Group>[];
-  onClickGroup: (groupId: string) => void;
-  refState: InfiniteRefState<HTMLDivElement>;
+  refState: InfiniteRefState<HTMLAnchorElement>;
   isLoading?: boolean;
 }
 
 function MyGroups({
-  groups, onClickGroup, refState, isLoading, children,
+  groups, refState, isLoading, children,
 }: PropsWithChildren<Props>): ReactElement {
   if (isEmpty(groups) || isEmpty(groups[0].items)) {
     return <>{children}</>;
@@ -32,7 +31,6 @@ function MyGroups({
               <MyGroup
                 key={group.groupId}
                 group={group}
-                onClick={onClickGroup}
                 ref={targetFalseThenValue(!isLastItem)(refState.lastItemRef)}
               />
             );

--- a/src/containers/auth/SignUpContainer.test.tsx
+++ b/src/containers/auth/SignUpContainer.test.tsx
@@ -42,10 +42,10 @@ describe('SignUpContainer', () => {
   context('로딩중인 경우', () => {
     given('isLoading', () => (true));
 
-    it('"로딩중..."문구가 나타나야만 한다', () => {
+    it('아무것도 나타나지 않아야만 한다', () => {
       const { container } = renderSignUpContainer();
 
-      expect(container).toHaveTextContent('로딩중...');
+      expect(container).toBeEmptyDOMElement();
     });
   });
 

--- a/src/containers/auth/SignUpContainer.tsx
+++ b/src/containers/auth/SignUpContainer.tsx
@@ -13,7 +13,7 @@ import { SignUpAdditionalForm } from '@/models/auth';
 import { body1Font, h2Font } from '@/styles/fontStyles';
 import Layout from '@/styles/Layout';
 
-function SignUpContainer(): ReactElement {
+function SignUpContainer(): ReactElement | null {
   const profile = useFetchUserProfile();
   const user = useGetUser();
   const { mutate } = useSignUp();
@@ -34,7 +34,7 @@ function SignUpContainer(): ReactElement {
   }, [user, mutate]);
 
   if (isAllLoading) {
-    return <div>로딩중...</div>;
+    return null;
   }
 
   if (profile.data) {

--- a/src/containers/myInfo/AppliedGroupsContainer.test.tsx
+++ b/src/containers/myInfo/AppliedGroupsContainer.test.tsx
@@ -1,7 +1,6 @@
 import { createRef } from 'react';
 
-import { fireEvent, render, screen } from '@testing-library/react';
-import { useRouter } from 'next/router';
+import { render, screen } from '@testing-library/react';
 
 import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useInfiniteFetchUserAppliedGroups from '@/hooks/api/group/useInfiniteFetchUserAppliedGroups';
@@ -11,18 +10,11 @@ import FIXTURE_PROFILE from '../../../fixtures/profile';
 
 import AppliedGroupsContainer from './AppliedGroupsContainer';
 
-jest.mock('next/router', () => ({
-  useRouter: jest.fn(),
-}));
 jest.mock('@/hooks/api/group/useInfiniteFetchUserAppliedGroups');
 jest.mock('@/hooks/api/auth/useFetchUserProfile');
 
 describe('AppliedGroupsContainer', () => {
-  const mockPush = jest.fn();
-
   beforeEach(() => {
-    mockPush.mockClear();
-
     (useInfiniteFetchUserAppliedGroups as jest.Mock).mockImplementation(() => ({
       query: {
         data: {
@@ -37,9 +29,6 @@ describe('AppliedGroupsContainer', () => {
         lastItemRef: jest.fn(),
         wrapperRef: createRef(),
       },
-    }));
-    (useRouter as jest.Mock).mockImplementation(() => ({
-      push: mockPush,
     }));
     (useFetchUserProfile as jest.Mock).mockImplementation(() => ({
       data: FIXTURE_PROFILE,
@@ -61,14 +50,10 @@ describe('AppliedGroupsContainer', () => {
   });
 
   context('로딩중이 아닌 경우', () => {
-    describe('group을 클릭한다', () => {
-      it('router.push가 해당 글 url과 함께 호출되어야만 한다', () => {
-        renderAppliedGroupsContainer();
+    it('신청한 팀에 대한 리스트가 나타나야만 한다', () => {
+      const { container } = renderAppliedGroupsContainer();
 
-        fireEvent.click(screen.getByText(FIXTURE_GROUP.title));
-
-        expect(mockPush).toBeCalledWith(`/detail/${FIXTURE_GROUP.groupId}`);
-      });
+      expect(container).toHaveTextContent(FIXTURE_GROUP.title);
     });
   });
 });

--- a/src/containers/myInfo/AppliedGroupsContainer.tsx
+++ b/src/containers/myInfo/AppliedGroupsContainer.tsx
@@ -1,7 +1,5 @@
 import React, { ReactElement } from 'react';
 
-import { useRouter } from 'next/router';
-
 import EmptyStateArea from '@/components/common/EmptyStateArea';
 import MyGroups from '@/components/myInfo/MyGroups';
 import MyGroupsSkeletonLoader from '@/components/myInfo/MyGroupsSkeletonLoader';
@@ -9,14 +7,11 @@ import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useInfiniteFetchUserAppliedGroups from '@/hooks/api/group/useInfiniteFetchUserAppliedGroups';
 
 function AppliedGroupsContainer(): ReactElement {
-  const router = useRouter();
   const { data: user } = useFetchUserProfile();
   const { query, refState } = useInfiniteFetchUserAppliedGroups({
     userUid: user?.uid,
     perPage: 10,
   });
-
-  const onClickGroup = (groupId: string) => router.push(`/detail/${groupId}`);
 
   if (query.isLoading || query.isIdle) {
     return <MyGroupsSkeletonLoader />;
@@ -26,7 +21,6 @@ function AppliedGroupsContainer(): ReactElement {
     <MyGroups
       refState={refState}
       groups={query.data.pages}
-      onClickGroup={onClickGroup}
       isLoading={query.isFetchingNextPage}
     >
       <EmptyStateArea

--- a/src/containers/myInfo/MyInfoSettingContainer.test.tsx
+++ b/src/containers/myInfo/MyInfoSettingContainer.test.tsx
@@ -59,10 +59,10 @@ describe('MyInfoSettingContainer', () => {
       isSuccess: false,
     }));
 
-    it('"로딩중..."문구가 나타나야만 한다', async () => {
+    it('아무것도 나타나지 않아야만 한다', async () => {
       const { container } = renderMyInfoSettingContainer();
 
-      await act(() => expect(container).toHaveTextContent('로딩중...'));
+      await act(() => expect(container).toBeEmptyDOMElement());
     });
   });
 

--- a/src/containers/myInfo/MyInfoSettingContainer.tsx
+++ b/src/containers/myInfo/MyInfoSettingContainer.tsx
@@ -12,7 +12,7 @@ import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useReauthenticateWithProvider from '@/hooks/api/auth/useReauthenticateWithProvider';
 import { DetailLayout } from '@/styles/Layout';
 
-function MyInfoSettingContainer(): ReactElement {
+function MyInfoSettingContainer(): ReactElement | null {
   const { replace } = useRouter();
   const [isReauthenticate, setIsReauthenticate] = useLocalStorage('isReauthenticate', false);
 
@@ -39,7 +39,7 @@ function MyInfoSettingContainer(): ReactElement {
   }, [isReauthenticate, auth]);
 
   if (isLoading || !isSuccess) {
-    return <>로딩중...</>;
+    return null;
   }
 
   return (

--- a/src/containers/myInfo/RecruitedGroupsContainer.test.tsx
+++ b/src/containers/myInfo/RecruitedGroupsContainer.test.tsx
@@ -1,7 +1,6 @@
 import { createRef } from 'react';
 
-import { fireEvent, render, screen } from '@testing-library/react';
-import { useRouter } from 'next/router';
+import { render, screen } from '@testing-library/react';
 
 import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useInfiniteFetchUserRecruitedGroups from '@/hooks/api/group/useInfiniteFetchUserRecruitedGroups';
@@ -11,18 +10,11 @@ import FIXTURE_PROFILE from '../../../fixtures/profile';
 
 import RecruitedGroupsContainer from './RecruitedGroupsContainer';
 
-jest.mock('next/router', () => ({
-  useRouter: jest.fn(),
-}));
 jest.mock('@/hooks/api/group/useInfiniteFetchUserRecruitedGroups');
 jest.mock('@/hooks/api/auth/useFetchUserProfile');
 
 describe('RecruitedGroupsContainer', () => {
-  const mockPush = jest.fn();
-
   beforeEach(() => {
-    mockPush.mockClear();
-
     (useInfiniteFetchUserRecruitedGroups as jest.Mock).mockImplementation(() => ({
       query: {
         data: {
@@ -37,9 +29,6 @@ describe('RecruitedGroupsContainer', () => {
         lastItemRef: jest.fn(),
         wrapperRef: createRef(),
       },
-    }));
-    (useRouter as jest.Mock).mockImplementation(() => ({
-      push: mockPush,
     }));
     (useFetchUserProfile as jest.Mock).mockImplementation(() => ({
       data: FIXTURE_PROFILE,
@@ -63,14 +52,10 @@ describe('RecruitedGroupsContainer', () => {
   context('로딩중이 아닌 경우', () => {
     given('isLoading', () => false);
 
-    describe('group을 클릭한다', () => {
-      it('router.push가 해당 글 url과 함께 호출되어야만 한다', () => {
-        renderRecruitedGroupsContainer();
+    it('모집한 팀에 대한 리스트가 나타나야만 한다', () => {
+      const { container } = renderRecruitedGroupsContainer();
 
-        fireEvent.click(screen.getByText(FIXTURE_GROUP.title));
-
-        expect(mockPush).toBeCalledWith(`/detail/${FIXTURE_GROUP.groupId}`);
-      });
+      expect(container).toHaveTextContent(FIXTURE_GROUP.title);
     });
   });
 });

--- a/src/containers/myInfo/RecruitedGroupsContainer.tsx
+++ b/src/containers/myInfo/RecruitedGroupsContainer.tsx
@@ -1,7 +1,5 @@
 import React, { ReactElement } from 'react';
 
-import { useRouter } from 'next/router';
-
 import EmptyStateArea from '@/components/common/EmptyStateArea';
 import MyGroups from '@/components/myInfo/MyGroups';
 import MyGroupsSkeletonLoader from '@/components/myInfo/MyGroupsSkeletonLoader';
@@ -9,14 +7,11 @@ import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useInfiniteFetchUserRecruitedGroups from '@/hooks/api/group/useInfiniteFetchUserRecruitedGroups';
 
 function RecruitedGroupsContainer(): ReactElement {
-  const router = useRouter();
   const { data: user } = useFetchUserProfile();
   const { query, refState } = useInfiniteFetchUserRecruitedGroups({
     userUid: user?.uid,
     perPage: 10,
   });
-
-  const onClickGroup = (groupId: string) => router.push(`/detail/${groupId}`);
 
   if (query.isLoading || query.isIdle) {
     return <MyGroupsSkeletonLoader />;
@@ -26,7 +21,6 @@ function RecruitedGroupsContainer(): ReactElement {
     <MyGroups
       refState={refState}
       groups={query.data.pages}
-      onClickGroup={onClickGroup}
       isLoading={query.isFetchingNextPage}
     >
       <EmptyStateArea

--- a/src/hooks/api/group/useInfiniteFetchUserAppliedGroups.ts
+++ b/src/hooks/api/group/useInfiniteFetchUserAppliedGroups.ts
@@ -38,7 +38,7 @@ function useInfiniteFetchUserAppliedGroups({ userUid, perPage }: UserAppliedGrou
     defaultErrorMessage: '신청한 팀을 불러오는데 실패했어요!',
   });
 
-  const refState = useIntersectionObserver<HTMLDivElement>({
+  const refState = useIntersectionObserver<HTMLAnchorElement>({
     intersectionOptions: {
       rootMargin: '20px',
     },

--- a/src/hooks/api/group/useInfiniteFetchUserRecruitedGroups.ts
+++ b/src/hooks/api/group/useInfiniteFetchUserRecruitedGroups.ts
@@ -38,7 +38,7 @@ function useInfiniteFetchUserRecruitedGroups({ userUid, perPage }: UserRecruited
     defaultErrorMessage: '모집한 팀을 불러오는데 실패했어요!',
   });
 
-  const refState = useIntersectionObserver<HTMLDivElement>({
+  const refState = useIntersectionObserver<HTMLAnchorElement>({
     intersectionOptions: {
       rootMargin: '20px',
     },

--- a/src/services/api/alarm.test.ts
+++ b/src/services/api/alarm.test.ts
@@ -3,7 +3,7 @@ import {
 } from 'firebase/firestore';
 
 import { AlarmForm } from '@/models/alarm';
-import { formatAlarm, formatCreatedAt } from '@/utils/firestore';
+import { formatAlarm, formatCreatedAt, isLessThanPerPage } from '@/utils/firestore';
 
 import ALARM_FIXTURE from '../../../fixtures/alarm';
 import FIXTURE_GROUP from '../../../fixtures/group';
@@ -91,6 +91,9 @@ describe('alarm API', () => {
             }],
           }));
           (formatAlarm as jest.Mock).mockReturnValueOnce(ALARM_FIXTURE);
+          (isLessThanPerPage as jest.Mock).mockImplementationOnce(
+            () => jest.fn().mockReturnValueOnce(true),
+          );
         });
 
         it('알람 리스트가 반환되어야만 한다', async () => {

--- a/src/services/api/applicants.test.ts
+++ b/src/services/api/applicants.test.ts
@@ -3,7 +3,7 @@ import {
 } from 'firebase/firestore';
 
 import { ApplicantFields } from '@/models/group';
-import { formatCreatedAt } from '@/utils/firestore';
+import { formatCreatedAt, isLessThanPerPage } from '@/utils/firestore';
 
 import APPLICANT_FIXTURE from '../../../fixtures/applicant';
 import GROUP_FIXTURE from '../../../fixtures/group';
@@ -152,6 +152,9 @@ describe('applicants API', () => {
             }],
           }));
           (getGroupDetail as jest.Mock).mockResolvedValue(GROUP_FIXTURE);
+          (isLessThanPerPage as jest.Mock).mockImplementationOnce(
+            () => jest.fn().mockReturnValueOnce(true),
+          );
         });
 
         it('그룹 리스트가 반환되어야만 한다', async () => {

--- a/src/services/api/comment.test.ts
+++ b/src/services/api/comment.test.ts
@@ -3,7 +3,7 @@ import {
 } from 'firebase/firestore';
 
 import { CommentFields } from '@/models/group';
-import { formatComment } from '@/utils/firestore';
+import { formatComment, isLessThanPerPage } from '@/utils/firestore';
 
 import COMMENT_FIXTURE from '../../../fixtures/comment';
 import PROFILE_FIXTURE from '../../../fixtures/profile';
@@ -105,6 +105,9 @@ describe('comment API', () => {
             }],
           }));
           (formatComment as jest.Mock).mockReturnValueOnce(COMMENT_FIXTURE);
+          (isLessThanPerPage as jest.Mock).mockImplementationOnce(
+            () => jest.fn().mockReturnValueOnce(true),
+          );
         });
 
         it('댓글 리스트가 반환되어야만 한다', async () => {

--- a/src/services/api/group.test.ts
+++ b/src/services/api/group.test.ts
@@ -17,7 +17,7 @@ import {
   patchNumberApplicants,
   postNewGroup,
 } from '@/services/api/group';
-import { formatGroup } from '@/utils/firestore';
+import { formatGroup, isLessThanPerPage } from '@/utils/firestore';
 
 import GROUP_FIXTURE from '../../../fixtures/group';
 import PROFILE_FIXTURE from '../../../fixtures/profile';
@@ -233,6 +233,9 @@ describe('group API', () => {
             }],
           }));
           (formatGroup as jest.Mock).mockReturnValueOnce(GROUP_FIXTURE);
+          (isLessThanPerPage as jest.Mock).mockImplementationOnce(
+            () => jest.fn().mockReturnValueOnce(true),
+          );
         });
 
         it('그룹 리스트가 반환되어야만 한다', async () => {

--- a/src/utils/__mocks__/firestore.ts
+++ b/src/utils/__mocks__/firestore.ts
@@ -7,3 +7,5 @@ export const formatComment = jest.fn();
 export const formatCreatedAt = jest.fn();
 
 export const formatAlarm = jest.fn();
+
+export const isLessThanPerPage = jest.fn().mockImplementation(() => jest.fn());

--- a/src/utils/firestore.test.ts
+++ b/src/utils/firestore.test.ts
@@ -1,4 +1,4 @@
-import { DocumentData, QueryDocumentSnapshot } from 'firebase/firestore';
+import { DocumentData, QueryDocumentSnapshot, QuerySnapshot } from 'firebase/firestore';
 
 import { getUserProfile } from '@/services/api/auth';
 
@@ -6,8 +6,7 @@ import GROUP_FIXTURE from '../../fixtures/group';
 import PROFILE_FIXTURE from '../../fixtures/profile';
 
 import {
-  formatAlarm,
-  formatComment, formatCreatedAt, formatGroup, timestampToString,
+  formatAlarm, formatComment, formatCreatedAt, formatGroup, isLessThanPerPage, timestampToString,
 } from './firestore';
 
 jest.mock('@/services/api/group');
@@ -163,6 +162,42 @@ describe('formatAlarm', () => {
         userUid: '2',
         applicant: null,
       });
+    });
+  });
+});
+
+describe('isLessThanPerPage', () => {
+  const perPage = 10;
+
+  const isLengthLessThanPerPage = isLessThanPerPage(10);
+
+  context(`documentData가 빈 배열이거나 ${perPage}보다 길이가 작은 경우`, () => {
+    const documentData = {
+      empty: true,
+      docs: {
+        length: 1,
+      },
+    } as unknown as QuerySnapshot<DocumentData>;
+
+    it('true를 반환해야만 한다', () => {
+      const result = isLengthLessThanPerPage(documentData);
+
+      expect(result).toBeTruthy();
+    });
+  });
+
+  context(`documentData가 빈 배열이 아니거나 ${perPage}보다 길이가 큰 경우`, () => {
+    const documentData = {
+      empty: false,
+      docs: {
+        length: 11,
+      },
+    } as unknown as QuerySnapshot<DocumentData>;
+
+    it('false를 반환해야만 한다', () => {
+      const result = isLengthLessThanPerPage(documentData);
+
+      expect(result).toBeFalsy();
     });
   });
 });

--- a/src/utils/firestore.ts
+++ b/src/utils/firestore.ts
@@ -1,4 +1,4 @@
-import { DocumentData, QueryDocumentSnapshot } from 'firebase/firestore';
+import type { DocumentData, QueryDocumentSnapshot, QuerySnapshot } from 'firebase/firestore';
 
 import { Alarm, AlarmResponse } from '@/models/alarm';
 import { Profile } from '@/models/auth';
@@ -64,3 +64,7 @@ export const formatAlarm = async (alarm: QueryDocumentSnapshot<DocumentData>) =>
     applicant: null,
   } as Alarm;
 };
+
+export const isLessThanPerPage = (perPage: number) => (
+  documentData: QuerySnapshot<DocumentData>,
+) => documentData.empty || documentData.docs.length < perPage;


### PR DESCRIPTION
- Infinite Scroll이 적용되어있는 리스트부분에서 다음 페이지가 존재하지 않을 경우 다음 페이지 키값이 존재해서 불필요하게 api가 다시 호출되는 이슈
- 처음 infinite scroll api 호출시 첫 페이지가 perPage 보다 작을 경우 발생
- 내 정보 페이지의 신청한 팀, 모집한 팀에서 router.push로 호출하고 있는 부분을 Link로 리팩터링