### PR TITLE
fix: 글이 모집이 완료가 된 글일 때 신청자 리스트로 이동하는 경우 해당 글로 이동하도록 수정하라

### DIFF
--- a/src/containers/auth/SignInModalContainer.test.tsx
+++ b/src/containers/auth/SignInModalContainer.test.tsx
@@ -42,22 +42,6 @@ describe('SignInModalContainer', () => {
     });
   });
 
-  context('query에 error가 존재한 경우', () => {
-    given('isVisible', () => true);
-    given('query', () => ({
-      error: 'OAuthAccountNotLinked',
-    }));
-
-    describe('모달창이 에러 문구와 함께 나타난다', () => {
-      it('"이미 가입된 이메일입니다." 문구가 나타나야만 하고, replace가 호출되어야만 한다', () => {
-        const { container } = renderSignInModalContainer();
-
-        expect(mockReplace).toBeCalledWith('/', undefined, { shallow: true });
-        expect(container).toHaveTextContent('이미 가입된 이메일입니다.');
-      });
-    });
-  });
-
   context('SignIn 모달이 열린 경우', () => {
     given('isVisible', () => true);
     it('"소셜 계정으로 계속하기" 문구가 나타야만 한다', () => {

--- a/src/containers/auth/SignInModalContainer.tsx
+++ b/src/containers/auth/SignInModalContainer.tsx
@@ -1,8 +1,5 @@
-import React, {
-  ReactElement, useEffect, useState,
-} from 'react';
+import React, { ReactElement, useState } from 'react';
 
-import { useRouter } from 'next/router';
 import { useRecoilState } from 'recoil';
 
 import SignInError from '@/components/auth/SignInError';
@@ -12,7 +9,6 @@ import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import { signInModalVisibleState } from '@/recoil/modal/atom';
 
 function SignInModalContainer(): ReactElement | null {
-  const { query, replace } = useRouter();
   const [isVisible, setSignInModalVisible] = useRecoilState(signInModalVisibleState);
   const { data: profile } = useFetchUserProfile();
 
@@ -22,14 +18,6 @@ function SignInModalContainer(): ReactElement | null {
     setSignInModalVisible(false);
     setError('');
   };
-
-  useEffect(() => {
-    if (query?.error && query.error !== 'unauthenticated') {
-      setSignInModalVisible(true);
-      setError(query.error as string);
-      replace('/', undefined, { shallow: true });
-    }
-  }, [query]);
 
   if (profile) {
     return null;

--- a/src/containers/home/RecruitPostsContainer.tsx
+++ b/src/containers/home/RecruitPostsContainer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useEffect } from 'react';
+import React, { ReactElement, useCallback } from 'react';
 
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
@@ -8,14 +8,20 @@ import RecruitPosts from '@/components/home/RecruitPosts';
 import RecruitPostsSkeletonLoader from '@/components/home/RecruitPostsSkeletonLoader';
 import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useFetchGroups from '@/hooks/api/group/useFetchGroups';
+import useRenderErrorToast from '@/hooks/useRenderErrorToast';
 import { signInModalVisibleState } from '@/recoil/modal/atom';
-import { errorToast } from '@/utils/toast';
 
 function RecruitPostsContainer(): ReactElement {
-  const { query, replace, push } = useRouter();
+  const { push } = useRouter();
   const { data: groups, isLoading } = useFetchGroups();
   const { data: user } = useFetchUserProfile();
   const setSignInModalVisible = useSetRecoilState(signInModalVisibleState);
+
+  useRenderErrorToast({
+    errorStatus: 'unauthenticated',
+    errorMessage: '접근 권한이 없는 페이지에요.',
+    replaceUrl: '/',
+  });
 
   const onClickEmptyButton = useCallback(() => {
     if (user) {
@@ -25,13 +31,6 @@ function RecruitPostsContainer(): ReactElement {
 
     setSignInModalVisible(true);
   }, [user]);
-
-  useEffect(() => {
-    if (query.error === 'unauthenticated') {
-      errorToast('접근 권한이 없는 페이지에요.');
-      replace('/', undefined, { shallow: true });
-    }
-  }, [query]);
 
   if (isLoading) {
     return (

--- a/src/hooks/useRenderErrorToast.test.ts
+++ b/src/hooks/useRenderErrorToast.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react';
+import { useRouter } from 'next/router';
+
+import { errorToast } from '@/utils/toast';
+
+import useRenderErrorToast from './useRenderErrorToast';
+
+jest.mock('@/utils/toast');
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('useRenderErrorToast', () => {
+  const errorMessage = '에러가 발생했어요!';
+  const errorStatus = 'unauthenticated';
+  const replaceUrl = '/';
+
+  const mockReplace = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useRouter as jest.Mock).mockImplementation(() => ({
+      replace: mockReplace,
+      query: given.query,
+    }));
+  });
+
+  const useRenderErrorToastHook = () => renderHook(() => useRenderErrorToast({
+    errorMessage,
+    errorStatus,
+    replaceUrl: '/',
+  }));
+
+  context('query.error가 errorStatus와 일치하는 경우', () => {
+    given('query', () => ({
+      error: errorStatus,
+    }));
+
+    it('"errorToast"가 메시지와 함꼐 호출되어야하고 replace가 url과 함께 호출되어야만 한다', () => {
+      useRenderErrorToastHook();
+
+      expect(errorToast).toBeCalledWith(errorMessage);
+      expect(mockReplace).toBeCalledWith(replaceUrl, undefined, { shallow: true });
+    });
+  });
+
+  context('query.error가 errorStatus와 일치하지 않는 경우', () => {
+    given('query', () => ({
+      error: 'already-completed',
+    }));
+
+    it('"errorToast"가 호출되지 않아야만 한다', () => {
+      useRenderErrorToastHook();
+
+      expect(errorToast).not.toBeCalled();
+    });
+  });
+});

--- a/src/hooks/useRenderErrorToast.ts
+++ b/src/hooks/useRenderErrorToast.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+
+import { useRouter } from 'next/router';
+
+import { errorToast } from '@/utils/toast';
+
+type TRenderErrorToast = {
+  errorStatus: 'unauthenticated' | 'already-completed';
+  errorMessage: string;
+  replaceUrl: string;
+}
+
+function useRenderErrorToast({ errorMessage, errorStatus, replaceUrl }: TRenderErrorToast) {
+  const { replace, query } = useRouter();
+
+  useEffect(() => {
+    if (query?.error === errorStatus) {
+      errorToast(errorMessage);
+      replace(replaceUrl, undefined, { shallow: true });
+    }
+  }, [query?.error, errorMessage, errorStatus, replaceUrl, replace]);
+}
+
+export default useRenderErrorToast;

--- a/src/pages/detail/[id].page.tsx
+++ b/src/pages/detail/[id].page.tsx
@@ -13,6 +13,7 @@ import DetailContentsContainer from '@/containers/detail/DetailContentsContainer
 import DetailHeaderContainer from '@/containers/detail/DetailHeaderContainer';
 import useFetchGroup from '@/hooks/api/group/useFetchGroup';
 import useIncreaseView from '@/hooks/api/group/useIncreaseView';
+import useRenderErrorToast from '@/hooks/useRenderErrorToast';
 import { GroupQuery } from '@/models';
 import { Group } from '@/models/group';
 import { getGroupDetail } from '@/services/api/group';
@@ -46,8 +47,14 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 };
 
 function DetailPage(): ReactElement {
-  useIncreaseView();
   const { data: group } = useFetchGroup();
+
+  useIncreaseView();
+  useRenderErrorToast({
+    errorStatus: 'already-completed',
+    errorMessage: '이미 모집이 완료되었어요.',
+    replaceUrl: `/detail/${group.groupId}`,
+  });
 
   return (
     <>

--- a/src/pages/detail/[id]/applicants.page.tsx
+++ b/src/pages/detail/[id]/applicants.page.tsx
@@ -31,7 +31,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     return {
       redirect: {
         permanent: false,
-        destination: '/?error=unauthenticated',
+        destination: `/detail/${group.groupId}/?error=already-completed`,
       },
       props: {},
     };

--- a/src/pages/detail/[id]/applicants.test.tsx
+++ b/src/pages/detail/[id]/applicants.test.tsx
@@ -86,7 +86,7 @@ describe('getServerSideProps', () => {
 
   context('이미 모집완료된 작성글인 경우', () => {
     const queryClient = new QueryClient();
-
+    const groupId = 1;
     const token = {
       uid: '1',
     };
@@ -94,6 +94,7 @@ describe('getServerSideProps', () => {
     beforeEach(() => {
       (getGroupDetail as jest.Mock).mockResolvedValue({
         isCompleted: true,
+        groupId,
       });
       (firebaseAdmin.auth as jest.Mock).mockImplementation(() => ({
         verifyIdToken: jest.fn().mockResolvedValue(token),
@@ -103,13 +104,13 @@ describe('getServerSideProps', () => {
       });
     });
 
-    it('redirect를 반환해야만 한다', async () => {
+    it('"already-completed" error와 함께 상세 페이지 redirect를 반환해야만 한다', async () => {
       const response: any = await getServerSideProps(mockContext as GetServerSidePropsContext);
 
       expect(getGroupDetail).toBeCalledWith('id');
       expect(response.redirect).toEqual({
         permanent: false,
-        destination: '/?error=unauthenticated',
+        destination: `/detail/${groupId}/?error=already-completed`,
       });
     });
   });
@@ -138,7 +139,7 @@ describe('getServerSideProps', () => {
       });
     });
 
-    it('redirect를 반환해야만 한다', async () => {
+    it('"unauthenticated" 에러와 함께 redirect를 반환해야만 한다', async () => {
       const response: any = await getServerSideProps(mockContext as GetServerSidePropsContext);
 
       expect(getGroupDetail).toBeCalledWith('id');
@@ -197,7 +198,7 @@ describe('getServerSideProps', () => {
       }));
     });
 
-    it('redirect를 반환해야만 한다', async () => {
+    it('"unauthenticated" 에러와 함께 redirect를 반환해야만 한다', async () => {
       const response: any = await getServerSideProps(mockContext as GetServerSidePropsContext);
 
       expect(response.redirect).toEqual({


### PR DESCRIPTION
- 알람에서 모집완료된 글 신청자 리스트 페이지로 이동할 경우
- 신청자 리스트 페이지는 모집이 완료되었으므로 접근할 수 없는 페이지
- 따라서 해당 글로 redirect시킨뒤 "이미 모집이 완료되었어요." 에러 토스트 메시지를 띄우도록 수정
- useRenderErrorToast hook 구현