### PR TITLE
fix: sign-up 페이지에서 닉네임이 입력되지 않은 경우 버튼이 disable되도록 수정하라

### DIFF
--- a/src/components/auth/SignUpForm.test.tsx
+++ b/src/components/auth/SignUpForm.test.tsx
@@ -86,8 +86,8 @@ describe('SignUpForm', () => {
 
     context('submit 호출에 실패했을 때', () => {
       context('닉네임을 입력하지 않은 경우', () => {
-        it('"닉네임을 입력해주세요." 에러 메시지가 보여진다', async () => {
-          const { container } = renderSignUpForm({
+        it('버튼은 disabled이어야만 한다', async () => {
+          renderSignUpForm({
             ...userFields,
             displayName: '',
           });
@@ -100,7 +100,8 @@ describe('SignUpForm', () => {
             await fireEvent.submit(button);
           });
 
-          expect(container).toHaveTextContent('닉네임을 입력해주세요.');
+          expect(handleSubmit).not.toBeCalled();
+          expect(button).toHaveAttribute('disabled');
         });
       });
 
@@ -117,6 +118,7 @@ describe('SignUpForm', () => {
           });
 
           expect(handleSubmit).not.toBeCalled();
+          expect(button).toHaveAttribute('disabled');
         });
       });
     });

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -28,8 +28,11 @@ const validationSchema = yup.object({
 
 function SignUpForm({ onSubmit, fields }: Props): ReactElement {
   const {
-    register, handleSubmit, setValue, formState: { errors },
-  } = useForm<SignUpAdditionalForm>({ resolver: yupResolver(validationSchema) });
+    register, handleSubmit, formState: { isValid, errors }, resetField,
+  } = useForm<SignUpAdditionalForm>({
+    resolver: yupResolver(validationSchema),
+    mode: 'onChange',
+  });
   const [, setIsSignUp] = useLocalStorage('isSignUp', false, {
     raw: true,
   });
@@ -52,7 +55,7 @@ function SignUpForm({ onSubmit, fields }: Props): ReactElement {
         labelText="닉네임"
         placeholder="닉네임을 입력해주세요"
         register={register('name')}
-        onClear={() => setValue('name', '')}
+        onClear={() => resetField('name')}
         defaultValue={stringToExcludeNull(fields?.displayName)}
         isError={!!errors.name}
         message={errors.name?.message}
@@ -80,10 +83,10 @@ function SignUpForm({ onSubmit, fields }: Props): ReactElement {
         labelOptionText="선택"
         placeholder="URL을 입력하세요"
         register={register('portfolioUrl')}
-        onClear={() => setValue('portfolioUrl', '')}
+        onClear={() => resetField('portfolioUrl')}
         type="url"
       />
-      <SubmitButton type="submit" color="success" size="large" disabled={!position}>
+      <SubmitButton type="submit" color="success" size="large" disabled={!isValid || !position}>
         확인
       </SubmitButton>
     </SignUpFormWrapper>

--- a/src/containers/auth/SignUpContainer.test.tsx
+++ b/src/containers/auth/SignUpContainer.test.tsx
@@ -51,10 +51,10 @@ describe('SignUpContainer', () => {
       photoURL: PROFILE_FIXTURE.image,
     }));
 
-    it('회원가입 페이지에 대한 정보 나타나야만 한다', () => {
+    it('회원가입 페이지에 대한 정보 나타나야만 한다', async () => {
       const { container } = renderSignUpContainer();
 
-      expect(container).toHaveTextContent('시작하기');
+      await act(() => expect(container).toHaveTextContent('시작하기'));
     });
 
     describe('"확인" 버튼을 클릭한다', () => {


### PR DESCRIPTION
- 시작하기 페이지에서 닉네임 input에 change이벤트가 일어났을때 validate하도록 수정
- 닉네임, 포지션이 입력이 안되어있으면 버튼 disabled