### PR TITLE
style: 모바일일 때 글 작성 페이지에서 스크롤 발생할 경우 타이틀과 editor 툴바 상단에 고정하도록 하라

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-images-uploading": "^3.1.6",
     "react-intersection-observer": "^9.2.2",
     "react-query": "^3.38.1",
-    "react-responsive": "^9.0.0-beta.6",
+    "react-responsive": "^9.0.0-beta.10",
     "react-select": "^5.3.1",
     "react-toastify": "^8.2.0",
     "react-toggle": "^4.1.2",

--- a/src/components/common/SubHeader.tsx
+++ b/src/components/common/SubHeader.tsx
@@ -4,8 +4,10 @@ import { ChevronLeft } from 'react-feather';
 
 import styled from '@emotion/styled';
 
-import { h4Font } from '@/styles/fontStyles';
+import useActionKeyEvent from '@/hooks/useActionKeyEvent';
+import { body1Font, h4Font } from '@/styles/fontStyles';
 import Layout from '@/styles/Layout';
+import mq, { mediaQueries } from '@/styles/responsive';
 import zIndexes from '@/styles/zIndexes';
 
 interface Props {
@@ -14,17 +16,30 @@ interface Props {
 }
 
 function SubHeader({ goBack, previousText, children }: PropsWithChildren<Props>): ReactElement {
+  const handleKeyDown = useActionKeyEvent<HTMLDivElement>('Enter', goBack);
+
   return (
     <>
       <HeaderBlock>
         <HeaderWrapper>
-          <div>
-            <ChevronLeft size={24} onClick={goBack} cursor="pointer" />
-            <GoBackButton onClick={goBack} type="button">
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={goBack}
+            onKeyDown={handleKeyDown}
+            style={{
+              cursor: 'pointer',
+            }}
+          >
+            <GoBackIcon size={24} />
+            <GoBackTitle data-testid="go-back-title">
               {previousText}
-            </GoBackButton>
+            </GoBackTitle>
           </div>
-          <div>
+          <div style={{
+            marginLeft: '40px',
+          }}
+          >
             {children}
           </div>
         </HeaderWrapper>
@@ -37,7 +52,9 @@ function SubHeader({ goBack, previousText, children }: PropsWithChildren<Props>)
 export default SubHeader;
 
 const Spacer = styled.div`
-  height: 4rem;
+  ${mq({
+    height: ['56px', '64px'],
+  })};
 `;
 
 const HeaderBlock = styled.div`
@@ -48,11 +65,15 @@ const HeaderBlock = styled.div`
 `;
 
 const HeaderWrapper = styled(Layout)`
+  ${mq({
+    height: ['56px', '64px'],
+  })};
+
+  width: calc(100% - 2rem);
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  height: 4rem;
 
   & > div {
     display: flex;
@@ -61,8 +82,28 @@ const HeaderWrapper = styled(Layout)`
   }
 `;
 
-const GoBackButton = styled.button`
-  ${h4Font(true)};
+const GoBackTitle = styled.div`
+  ${mediaQueries[0]} {
+    ${h4Font(true)};
+  }
+
+  ${body1Font(true)};
   background: transparent;
   color: ${({ theme }) => theme.foreground};
+  word-break: break-all;
+  overflow-wrap: break-word;
+  text-overflow: ellipsis;
+  display: -webkit-inline-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`;
+
+const GoBackIcon = styled(ChevronLeft)`
+  ${mq({
+    marginRight: ['8px', '16px'],
+  })};
+
+  min-height: 24px;
+  min-width: 24px;
 `;

--- a/src/components/write/EditorToolbar.test.tsx
+++ b/src/components/write/EditorToolbar.test.tsx
@@ -1,7 +1,10 @@
 import { useActive, useChainedCommands } from '@remirror/react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  act, fireEvent, render, screen,
+} from '@testing-library/react';
 
 import { lightTheme } from '@/styles/theme';
+import InjectResponsiveContext from '@/test/InjectResponsiveContext';
 import MockTheme from '@/test/MockTheme';
 
 import EditorToolbar from './EditorToolbar';
@@ -11,6 +14,7 @@ jest.mock('@remirror/react');
 describe('EditorToolbar', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
 
     (useActive as jest.Mock).mockImplementation(() => ({
       bold: jest.fn().mockImplementation(() => (given.isBold)),
@@ -27,11 +31,72 @@ describe('EditorToolbar', () => {
     }));
   });
 
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
   const renderEditorToolbar = () => render((
-    <MockTheme>
-      <EditorToolbar />
-    </MockTheme>
+    <InjectResponsiveContext width={given.width}>
+      <MockTheme>
+        <EditorToolbar />
+      </MockTheme>
+    </InjectResponsiveContext>
   ));
+
+  context('모바일 환경인 경우', () => {
+    given('width', () => 400);
+
+    describe('스크롤 위치에 따라 툴바 스타일이 변경된다', () => {
+      context('스크롤 높이가 56이하인 경우', () => {
+        it('box-shadow가 "transparent"가 되어야 한다', () => {
+          renderEditorToolbar();
+
+          expect(screen.getByTestId('editor-toolbar-wrapper')).toHaveStyle({
+            'box-shadow': '0 1px 0 0 transparent',
+          });
+        });
+      });
+
+      context('스크롤 높이가 56보다 큰 경우', () => {
+        it(`box-shadow 속성이 ${lightTheme.accent2} 이어야 한다`, async () => {
+          renderEditorToolbar();
+
+          await act(async () => {
+            fireEvent.scroll(window, { target: { scrollY: 200 } });
+            await jest.advanceTimersByTime(200);
+          });
+
+          expect(screen.getByTestId('editor-toolbar-wrapper')).toHaveStyle({
+            'box-shadow': `0 1px 0 0 ${lightTheme.accent2}`,
+          });
+        });
+      });
+
+      context('스크롤 left값이 0인 경우', () => {
+        it('"left-shadow-block"의 opacity값은 0이여만 한다', () => {
+          renderEditorToolbar();
+
+          fireEvent.scroll(screen.getByTestId('editor-toolbar-wrapper'), { target: { scrollLeft: 0 } });
+
+          expect(screen.getByTestId('left-shadow-block')).toHaveStyle({
+            opacity: 0,
+          });
+        });
+      });
+
+      context('스크롤 left값이 툴바 최대 수평 길이와 같은 경우', () => {
+        it('"right-shadow-block"의 opacity값은 0이여만 한다', () => {
+          renderEditorToolbar();
+
+          fireEvent.scroll(screen.getByTestId('editor-toolbar-wrapper'), { target: { scrollLeft: 0 } });
+
+          expect(screen.getByTestId('right-shadow-block')).toHaveStyle({
+            opacity: 0,
+          });
+        });
+      });
+    });
+  });
 
   describe('bold 버튼을 클릭한다', () => {
     it('클릭이벤트가 발생해야만 한다', () => {
@@ -39,7 +104,7 @@ describe('EditorToolbar', () => {
 
       fireEvent.click(screen.getByTestId('bold-button'));
 
-      expect(useChainedCommands).toBeCalledTimes(1);
+      expect(useChainedCommands).toBeCalled();
     });
   });
 
@@ -49,7 +114,7 @@ describe('EditorToolbar', () => {
 
       fireEvent.click(screen.getByTestId('h1-button'));
 
-      expect(useChainedCommands).toBeCalledTimes(1);
+      expect(useChainedCommands).toBeCalled();
     });
   });
 
@@ -59,7 +124,7 @@ describe('EditorToolbar', () => {
 
       fireEvent.click(screen.getByTestId('h2-button'));
 
-      expect(useChainedCommands).toBeCalledTimes(1);
+      expect(useChainedCommands).toBeCalled();
     });
   });
 
@@ -69,7 +134,7 @@ describe('EditorToolbar', () => {
 
       fireEvent.click(screen.getByTestId('h3-button'));
 
-      expect(useChainedCommands).toBeCalledTimes(1);
+      expect(useChainedCommands).toBeCalled();
     });
   });
 
@@ -79,7 +144,7 @@ describe('EditorToolbar', () => {
 
       fireEvent.click(screen.getByTestId('italic-button'));
 
-      expect(useChainedCommands).toBeCalledTimes(1);
+      expect(useChainedCommands).toBeCalled();
     });
   });
 
@@ -89,7 +154,7 @@ describe('EditorToolbar', () => {
 
       fireEvent.click(screen.getByTestId('underline-button'));
 
-      expect(useChainedCommands).toBeCalledTimes(1);
+      expect(useChainedCommands).toBeCalled();
     });
   });
 
@@ -99,7 +164,7 @@ describe('EditorToolbar', () => {
 
       fireEvent.click(screen.getByTestId('strike-button'));
 
-      expect(useChainedCommands).toBeCalledTimes(1);
+      expect(useChainedCommands).toBeCalled();
     });
   });
 
@@ -109,7 +174,7 @@ describe('EditorToolbar', () => {
 
       fireEvent.click(screen.getByTestId('blockquote-button'));
 
-      expect(useChainedCommands).toBeCalledTimes(1);
+      expect(useChainedCommands).toBeCalled();
     });
   });
 
@@ -119,7 +184,7 @@ describe('EditorToolbar', () => {
 
       fireEvent.click(screen.getByTestId('code-block-button'));
 
-      expect(useChainedCommands).toBeCalledTimes(1);
+      expect(useChainedCommands).toBeCalled();
     });
   });
 
@@ -129,7 +194,7 @@ describe('EditorToolbar', () => {
 
       fireEvent.click(screen.getByTestId('bullet-list-button'));
 
-      expect(useChainedCommands).toBeCalledTimes(1);
+      expect(useChainedCommands).toBeCalled();
     });
   });
 
@@ -139,7 +204,7 @@ describe('EditorToolbar', () => {
 
       fireEvent.click(screen.getByTestId('ordered-list-button'));
 
-      expect(useChainedCommands).toBeCalledTimes(1);
+      expect(useChainedCommands).toBeCalled();
     });
   });
 

--- a/src/components/write/WriteEditor.tsx
+++ b/src/components/write/WriteEditor.tsx
@@ -160,6 +160,7 @@ const RemirrorEditorWrapper = styled(CoreStyledComponent)`
     ${body1Font()}
     min-height: 258px;
     outline: none;
+    overflow-y: auto !important;
 
     &:focus-visible {
       outline: none;

--- a/src/components/write/WriteForm.tsx
+++ b/src/components/write/WriteForm.tsx
@@ -50,6 +50,7 @@ export default WriteForm;
 const WriteFormWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  position: relative;
   margin-bottom: 80px;
 `;
 

--- a/src/containers/common/HeaderContainer.test.tsx
+++ b/src/containers/common/HeaderContainer.test.tsx
@@ -1,4 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  act, fireEvent, render, screen,
+} from '@testing-library/react';
 import { useRouter } from 'next/router';
 import { useSetRecoilState } from 'recoil';
 
@@ -25,6 +27,7 @@ describe('HeaderContainer', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
 
     (useSignOut as jest.Mock).mockImplementation(() => ({ mutate }));
     (useSetRecoilState as jest.Mock).mockImplementation(() => setSignInModalVisible);
@@ -38,6 +41,10 @@ describe('HeaderContainer', () => {
     (useFetchAlertAlarms as jest.Mock).mockImplementation(() => ({
       data: [1, 2, 3],
     }));
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
   });
 
   const renderHeaderContainer = () => render((
@@ -60,10 +67,13 @@ describe('HeaderContainer', () => {
     });
 
     context('스크롤 위치가 최상단이 아닐 경우', () => {
-      it(`box-shadow 속성이 ${lightTheme.accent2} 이어야 한다`, () => {
+      it(`box-shadow 속성이 ${lightTheme.accent2} 이어야 한다`, async () => {
         renderHeaderContainer();
 
-        fireEvent.scroll(window, { target: { scrollY: 200 } });
+        await act(async () => {
+          fireEvent.scroll(window, { target: { scrollY: 200 } });
+          await jest.advanceTimersByTime(200);
+        });
 
         expect(screen.getByTestId('header-block')).toHaveStyle({
           'box-shadow': `0 1px 0 0 ${lightTheme.accent2}`,

--- a/src/containers/common/HeaderContainer.tsx
+++ b/src/containers/common/HeaderContainer.tsx
@@ -1,5 +1,5 @@
 import React, {
-  ReactElement, useCallback, useEffect, useState,
+  ReactElement, useCallback,
 } from 'react';
 
 import { useRouter } from 'next/router';
@@ -8,30 +8,24 @@ import { useSetRecoilState } from 'recoil';
 import Header from '@/components/common/Header';
 import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useSignOut from '@/hooks/api/auth/useSignOut';
+import useLessThenScrollY from '@/hooks/useLessThenScrollY';
 import { signInModalVisibleState } from '@/recoil/modal/atom';
 
 function HeaderContainer(): ReactElement {
   const { pathname } = useRouter();
-  const setSignInModalVisible = useSetRecoilState(signInModalVisibleState);
-  const { data: user, isLoading } = useFetchUserProfile();
   const { mutate } = useSignOut();
-  const [isScrollTop, setIsScrollTop] = useState<boolean>(true);
+  const { data: user, isLoading } = useFetchUserProfile();
+
+  const setSignInModalVisible = useSetRecoilState(signInModalVisibleState);
+  const isBodyScrollTop = useLessThenScrollY();
 
   const onClickSignIn = () => setSignInModalVisible(true);
   const signOut = useCallback(() => mutate(), [mutate]);
 
-  const handleScrollAction = useCallback(() => setIsScrollTop(window.scrollY === 0), []);
-
-  useEffect(() => {
-    window.addEventListener('scroll', handleScrollAction);
-
-    return () => window.removeEventListener('scroll', handleScrollAction);
-  }, [handleScrollAction]);
-
   return (
     <Header
       signOut={signOut}
-      isScrollTop={isScrollTop}
+      isScrollTop={isBodyScrollTop}
       onClick={onClickSignIn}
       user={user}
       hasBackground={pathname === '/'}

--- a/src/containers/write/WriteHeaderContainer.tsx
+++ b/src/containers/write/WriteHeaderContainer.tsx
@@ -7,16 +7,37 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import Button from '@/components/common/Button';
 import SubHeader from '@/components/common/SubHeader';
+import useLessThenScrollY from '@/hooks/useLessThenScrollY';
+import useResponsive from '@/hooks/useResponsive';
 import { writeFieldsState } from '@/recoil/group/atom';
 import { publishModalVisibleState } from '@/recoil/modal/atom';
 
 function WriteHeaderContainer(): ReactElement {
   const router = useRouter();
-  const setPublishModalVisible = useSetRecoilState(publishModalVisibleState);
+  const { isMobile, isClient } = useResponsive();
+  const isLessThenScrollY = useLessThenScrollY(30);
+
   const { title } = useRecoilValue(writeFieldsState);
+  const setPublishModalVisible = useSetRecoilState(publishModalVisibleState);
   const [isEdit, setIsEdit] = useState<boolean>(false);
 
-  const onSubmit = () => setPublishModalVisible(true);
+  const onOpenPublishModal = () => setPublishModalVisible(true);
+
+  const previousText = () => {
+    if (!isClient) {
+      return '';
+    }
+
+    if (isMobile) {
+      return isLessThenScrollY ? '' : title;
+    }
+
+    if (isEdit) {
+      return '글 수정하기';
+    }
+
+    return '팀 모집하기';
+  };
 
   useEffect(() => {
     if (router.query?.id) {
@@ -27,14 +48,14 @@ function WriteHeaderContainer(): ReactElement {
   return (
     <SubHeader
       goBack={() => router.back()}
-      previousText={isEdit ? '글 수정하기' : '팀 모집하기'}
+      previousText={previousText()}
     >
       <Button
         type="button"
         size="small"
         color="success"
         disabled={!title.trim()}
-        onClick={onSubmit}
+        onClick={onOpenPublishModal}
       >
         {isEdit ? '저장하기' : '등록하기'}
       </Button>

--- a/src/hooks/useActionKeyEvent.test.ts
+++ b/src/hooks/useActionKeyEvent.test.ts
@@ -1,0 +1,44 @@
+import { KeyboardEvent } from 'react';
+
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import useActionKeyEvent from './useActionKeyEvent';
+
+describe('useActionKeyEvent', () => {
+  const callback = jest.fn();
+  const code = 'Enter';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const useActionKeyEventHook = () => renderHook(() => useActionKeyEvent(code, callback));
+
+  context('key code가 같은 경우', () => {
+    const mockEvent = {
+      code,
+    } as KeyboardEvent;
+
+    it('callback 함수가 호출되어야만 한다', () => {
+      const { result } = useActionKeyEventHook();
+
+      act(() => result.current(mockEvent));
+
+      expect(callback).toBeCalledTimes(1);
+    });
+  });
+
+  context('key code가 다른 경우', () => {
+    const mockEvent = {
+      code: 'Escape',
+    } as KeyboardEvent;
+
+    it('callback 함수가 호출되지 않아야만 한다', () => {
+      const { result } = useActionKeyEventHook();
+
+      act(() => result.current(mockEvent));
+
+      expect(callback).not.toBeCalled();
+    });
+  });
+});

--- a/src/hooks/useActionKeyEvent.ts
+++ b/src/hooks/useActionKeyEvent.ts
@@ -1,0 +1,17 @@
+import { KeyboardEvent, KeyboardEventHandler, useCallback } from 'react';
+
+// NOTE: keyboard event code - https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values
+function useActionKeyEvent<T = Element>(
+  targetKey?: string,
+  callback?: () => void,
+): KeyboardEventHandler<T> {
+  const onKeyEvent: KeyboardEventHandler<T> = useCallback((e: KeyboardEvent<T>) => {
+    if (e.code === targetKey) {
+      callback?.();
+    }
+  }, [targetKey, callback]);
+
+  return onKeyEvent;
+}
+
+export default useActionKeyEvent;

--- a/src/hooks/useLessThenScrollY.test.ts
+++ b/src/hooks/useLessThenScrollY.test.ts
@@ -1,0 +1,45 @@
+import { act, fireEvent, renderHook } from '@testing-library/react';
+
+import useLessThenScrollY from './useLessThenScrollY';
+
+describe('useLessThenScrollY', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  const useLessThenScrollYHook = () => renderHook(() => useLessThenScrollY(given.scrollY));
+
+  context('스크롤 위치가 기준값보다 작거나 같은 경우', () => {
+    const scrollY = 50;
+
+    given('scrollY', () => scrollY);
+
+    it('true를 반환해야만 한다', async () => {
+      const { result } = useLessThenScrollYHook();
+
+      await act(async () => {
+        fireEvent.scroll(window, { target: { scrollY } });
+        jest.advanceTimersByTime(200);
+      });
+
+      expect(result.current).toBeTruthy();
+    });
+  });
+
+  context('스크롤 위치가 기준값보다 큰 경우', () => {
+    it('false를 반환해야만 한다', async () => {
+      const { result } = useLessThenScrollYHook();
+
+      await act(async () => {
+        fireEvent.scroll(window, { target: { scrollY: 200 } });
+        jest.advanceTimersByTime(200);
+      });
+
+      expect(result.current).toBeFalsy();
+    });
+  });
+});

--- a/src/hooks/useLessThenScrollY.ts
+++ b/src/hooks/useLessThenScrollY.ts
@@ -1,0 +1,26 @@
+import {
+  useCallback, useEffect, useState,
+} from 'react';
+
+import useThrottleCallback from './useThrottleCallback';
+
+function useLessThenScrollY(targetScrollY = 0): boolean {
+  const [isLessThenScrollY, setIsLessThenScrollY] = useState<boolean>(true);
+
+  const handleScrollAction = useCallback(
+    () => setIsLessThenScrollY(window.scrollY <= targetScrollY),
+    [targetScrollY],
+  );
+
+  const throttledCallback = useThrottleCallback(handleScrollAction, 200);
+
+  useEffect(() => {
+    window.addEventListener('scroll', throttledCallback);
+
+    return () => window.removeEventListener('scroll', throttledCallback);
+  }, [throttledCallback]);
+
+  return isLessThenScrollY;
+}
+
+export default useLessThenScrollY;

--- a/src/hooks/useThrottleCallback.test.ts
+++ b/src/hooks/useThrottleCallback.test.ts
@@ -1,0 +1,45 @@
+import { act, renderHook } from '@testing-library/react';
+
+import useThrottleCallback from './useThrottleCallback';
+
+describe('useThrottleCallback', () => {
+  const delay = 200;
+  const callback = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  const useThrottleCallbackHook = () => renderHook(() => useThrottleCallback(callback, delay));
+
+  context('delay 시간이 되지 않은 경우', () => {
+    it('callback 함수가 호출되지 않아야만 한다', async () => {
+      const { result } = useThrottleCallbackHook();
+
+      await act(async () => {
+        result.current();
+        jest.advanceTimersByTime(100);
+      });
+
+      expect(callback).not.toBeCalled();
+    });
+  });
+
+  context('delay 시간이 된 경우', () => {
+    it('callback 함수가 호출되어야만 한다', async () => {
+      const { result } = useThrottleCallbackHook();
+
+      await act(async () => {
+        result.current();
+        jest.advanceTimersByTime(delay);
+      });
+
+      expect(callback).toBeCalled();
+    });
+  });
+});

--- a/src/hooks/useThrottleCallback.ts
+++ b/src/hooks/useThrottleCallback.ts
@@ -1,0 +1,21 @@
+import { useCallback, useRef } from 'react';
+
+function useThrottleCallback<U extends any[]>(
+  callback: (...args: U) => void,
+  delay: number,
+) {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const throttledCallback = useCallback((...args: U) => {
+    if (!timer.current) {
+      timer.current = setTimeout(() => {
+        callback(...args);
+        timer.current = null;
+      }, delay);
+    }
+  }, [callback, delay]);
+
+  return throttledCallback;
+}
+
+export default useThrottleCallback;

--- a/src/utils/toast.tsx
+++ b/src/utils/toast.tsx
@@ -8,19 +8,19 @@ import { lightTheme } from '@/styles/theme';
 
 import SuccessIcon from '../assets/icons/check.svg';
 
-export const errorToast = (message: string, toastOptions?: ToastOptions<{}>) => toast
+export const errorToast = (message: string, toastOptions?: ToastOptions) => toast
   .error(message, {
     icon: <StyledWarnIcon fill={lightTheme.warning} color={lightTheme.background} />,
     ...toastOptions,
   });
 
-export const successToast = (message: string, toastOptions?: ToastOptions<{}>) => toast
+export const successToast = (message: string, toastOptions?: ToastOptions) => toast
   .success(message, {
     icon: <SuccessIcon />,
     ...toastOptions,
   });
 
-export const defaultToast = (message: string, toastOptions?: ToastOptions<{}>) => toast
+export const defaultToast = (message: string, toastOptions?: ToastOptions) => toast
   .info(message, {
     icon: <StyledDefaultIcon fill={lightTheme.accent2} color={lightTheme.accent8} />,
     ...toastOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15193,10 +15193,10 @@ react-refresh@^0.11.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
-react-responsive@^9.0.0-beta.6:
-  version "9.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-9.0.0-beta.6.tgz#78dcc9c2af3b176dfa4088dae617a73dba8adbe7"
-  integrity sha512-Flk6UrnpBBByreva6ja/TsbXiXq4BXOlDEKL6Ur+nshUs3CcN5W0BpGe6ClFWrKcORkMZAAYy7A4N4xlMmpgVw==
+react-responsive@^9.0.0-beta.10:
+  version "9.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-9.0.0-beta.10.tgz#892db936da48eb30babf5cb7e31737c7b5677209"
+  integrity sha512-41H8g4FYP46ln16rsHvs9/0ZoZxAPfnNiHET86/5pgS+Vw8fSKfLBuOS2SAquaxOxq7DgPviFoHmybgVvSKCNQ==
   dependencies:
     hyphenate-style-name "^1.0.0"
     matchmediaquery "^0.3.0"


### PR DESCRIPTION
- Sub Header 반응형 적용 및 클릭 이벤트 수정
- 모바일일 때 툴바 컨텐츠가 스크롤이 넘어가는 경우 좌우 shadow 적용
- 글 작성 툴바 반응형 적용
- useActionKeyEvent hook 구현
- useLessThenScrollY hook 구현
- useThrottleCallback hook 구현
- 모바일일 때 타이틀과 editor 툴바를 상단에 고정하도록 구현
- react18 strict mode일 경우 react-responsive가 정상적으로 동작하지 않는 이슈 해결
  - update react-responsive dependency (https://github.com/yocontra/react-responsive/pull/294)