### PR TITLE
feat: 내 정보 수정 페이지에서 이미지 삭제 클릭시 로직을 추가하라

### DIFF
--- a/src/components/myInfo/ImageSetting.test.tsx
+++ b/src/components/myInfo/ImageSetting.test.tsx
@@ -1,10 +1,16 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import ImageSetting from './ImageSetting';
 
 describe('ImageSetting', () => {
+  const handleDelete = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   const renderImageSetting = () => render((
-    <ImageSetting />
+    <ImageSetting imageUrl="/test" onDelete={handleDelete} />
   ));
 
   it('내 이미지에 대한 정보가 나타나야만 한다', () => {
@@ -12,5 +18,15 @@ describe('ImageSetting', () => {
 
     expect(container).toHaveTextContent('이미지 선택');
     expect(container).toHaveTextContent('이미지 삭제');
+  });
+
+  describe('"이미지 삭제" 버튼을 클릭한다', () => {
+    it('클릭 이벤트가 발생해야만 한다', () => {
+      renderImageSetting();
+
+      fireEvent.click(screen.getByText('이미지 삭제'));
+
+      expect(handleDelete).toBeCalledTimes(1);
+    });
   });
 });

--- a/src/components/myInfo/ImageSetting.tsx
+++ b/src/components/myInfo/ImageSetting.tsx
@@ -6,13 +6,14 @@ import Button from '../common/Button';
 import ProfileImage from '../common/ProfileImage';
 
 interface Props {
-  image?: string | null;
+  imageUrl?: string | null;
+  onDelete: () => void;
 }
 
-function ImageSetting({ image }: Props):ReactElement {
+function ImageSetting({ imageUrl, onDelete }: Props):ReactElement {
   return (
     <ImageSettingWrapper>
-      <ProfileImage src={image} size="96px" alt="프로필 이미지" />
+      <ProfileImage src={imageUrl} size="96px" alt="프로필 이미지" />
       <Button
         size="small"
         color="primary"
@@ -22,6 +23,7 @@ function ImageSetting({ image }: Props):ReactElement {
       <Button
         size="small"
         color="ghost"
+        onClick={onDelete}
       >
         이미지 삭제
       </Button>

--- a/src/containers/myInfo/MyInfoSettingContainer.tsx
+++ b/src/containers/myInfo/MyInfoSettingContainer.tsx
@@ -11,6 +11,9 @@ import useAccountWithdrawal from '@/hooks/api/auth/useAccountWithdrawal';
 import useAuthRedirectResult from '@/hooks/api/auth/useAuthRedirectResult';
 import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useReauthenticateWithProvider from '@/hooks/api/auth/useReauthenticateWithProvider';
+import useUpdateUser from '@/hooks/api/auth/useUpdateUser';
+import useDeleteStorageFile from '@/hooks/api/storage/useDeleteStorageFile';
+import { Profile } from '@/models/auth';
 import { DetailLayout } from '@/styles/Layout';
 
 function MyInfoSettingContainer(): ReactElement | null {
@@ -21,11 +24,24 @@ function MyInfoSettingContainer(): ReactElement | null {
   const { data: auth } = useAuthRedirectResult();
   const { mutate: reauthenticate } = useReauthenticateWithProvider();
   const { mutate: deleteUser } = useAccountWithdrawal();
+  const { mutate: deleteStorageUserImage } = useDeleteStorageFile();
+  const { mutate: deleteProfileImage } = useUpdateUser();
 
   const onWithdrawal = useCallback(() => {
     setIsReauthenticate(true);
     reauthenticate();
   }, []);
+
+  const onDeleteProfileImage = useCallback(() => {
+    if (user?.image?.startsWith('https://firebasestorage.googleapis.com')) {
+      deleteStorageUserImage(user.image);
+    }
+
+    deleteProfileImage({
+      ...user as Profile,
+      image: null,
+    });
+  }, [user, deleteStorageUserImage, deleteProfileImage]);
 
   useEffect(() => {
     if (!isLoading && isSuccess && !user) {
@@ -45,7 +61,7 @@ function MyInfoSettingContainer(): ReactElement | null {
 
   return (
     <SettingFormLayout>
-      <ImageSetting image={user?.image} />
+      <ImageSetting imageUrl={user?.image} onDelete={onDeleteProfileImage} />
       <SettingForm user={user} onWithdrawal={onWithdrawal} />
     </SettingFormLayout>
   );

--- a/src/hooks/api/auth/useUpdateUser.test.ts
+++ b/src/hooks/api/auth/useUpdateUser.test.ts
@@ -1,0 +1,36 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { updateUserProfile } from '@/services/api/auth';
+import wrapper from '@/test/ReactQueryWrapper';
+
+import PROFILE_FIXTURE from '../../../../fixtures/profile';
+
+import useUpdateUser from './useUpdateUser';
+
+jest.mock('@/services/api/auth');
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('useUpdateUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (updateUserProfile as jest.Mock).mockResolvedValue(null);
+  });
+
+  const useUpdateUserHook = () => renderHook(() => useUpdateUser(), {
+    wrapper,
+  });
+
+  it('updateUserProfile가 호출해야만 한다', async () => {
+    const { result } = useUpdateUserHook();
+
+    await act(async () => {
+      await result.current.mutate(PROFILE_FIXTURE);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBeTruthy());
+    expect(updateUserProfile).toBeCalledWith(PROFILE_FIXTURE);
+  });
+});

--- a/src/hooks/api/auth/useUpdateUser.ts
+++ b/src/hooks/api/auth/useUpdateUser.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AuthError } from 'firebase/auth';
+
+import { Profile } from '@/models/auth';
+import { updateUserProfile } from '@/services/api/auth';
+
+import useCatchAuthErrorWithToast from '../useCatchAuthErrorWithToast';
+
+function useUpdateUser() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation<void, AuthError, Profile>((profile) => updateUserProfile(profile), {
+    onSuccess: () => {
+      queryClient.invalidateQueries(['user']);
+      queryClient.invalidateQueries(['profile']);
+      queryClient.invalidateQueries(['token']);
+      queryClient.invalidateQueries(['authRedirectResult']);
+    },
+  });
+
+  const { isError, error } = mutation;
+
+  useCatchAuthErrorWithToast({
+    isError,
+    error,
+    defaultErrorMessage: '프로필 이미지 삭제에 실패했어요!',
+  });
+
+  return mutation;
+}
+
+export default useUpdateUser;

--- a/src/services/api/__mocks__/auth.ts
+++ b/src/services/api/__mocks__/auth.ts
@@ -11,3 +11,5 @@ export const getAuthRedirectResult = jest.fn();
 export const deleteMember = jest.fn();
 
 export const postReauthenticateWithProvider = jest.fn();
+
+export const updateUserProfile = jest.fn();


### PR DESCRIPTION
- 내 정보 수정 > 이미지 삭제 클릭시 이미지 삭제 로직 구현
- 이미지가 firebase storage에 저장 중이면 storage에서 삭제 그렇지 않다면 프로필 이미지만 삭제