### PR TITLE
fix: 내 정보 수정 페이지의 이미지 삭제 및 수정 시 api가 중복해서 발생하는 이슈를 수정하라

### DIFF
--- a/src/containers/myInfo/MyInfoSettingContainer.test.tsx
+++ b/src/containers/myInfo/MyInfoSettingContainer.test.tsx
@@ -11,6 +11,7 @@ import useDeleteStorageFile from '@/hooks/api/storage/useDeleteStorageFile';
 import useUploadStorageFile from '@/hooks/api/storage/useUploadStorageFile';
 import ReactQueryWrapper from '@/test/ReactQueryWrapper';
 import renderWithPortal from '@/test/renderWithPortal';
+import { successToast } from '@/utils/toast';
 
 import FIXTURE_PROFILE from '../../../fixtures/profile';
 
@@ -23,6 +24,7 @@ jest.mock('@/hooks/api/storage/useDeleteStorageFile');
 jest.mock('@/hooks/api/auth/useReauthenticateWithProvider');
 jest.mock('@/hooks/api/storage/useUploadStorageFile');
 jest.mock('@/hooks/api/auth/useUpdateUser');
+jest.mock('@/utils/toast');
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
 }));
@@ -30,6 +32,7 @@ jest.mock('next/router', () => ({
 describe('MyInfoSettingContainer', () => {
   const mockReplace = jest.fn();
   const mutate = jest.fn();
+  const reset = jest.fn();
   const uploadProfileImageUrl = 'https://test.test';
 
   beforeEach(() => {
@@ -55,12 +58,14 @@ describe('MyInfoSettingContainer', () => {
     }));
     (useUpdateUser as jest.Mock).mockImplementation(() => ({
       mutate,
-      isSuccess: false,
+      isSuccess: given.isSuccessUpdate,
+      reset,
     }));
     (useUploadStorageFile as jest.Mock).mockImplementation(() => ({
       data: uploadProfileImageUrl,
       isSuccess: given.isSuccessUpload,
       mutate,
+      reset,
     }));
   });
 
@@ -181,6 +186,17 @@ describe('MyInfoSettingContainer', () => {
           });
         });
       });
+
+      context('프로필 업데이트에 성공한 경우', () => {
+        given('isSuccessUpdate', () => true);
+
+        it('토스트 메시지가 호출되어야만 한다', () => {
+          renderMyInfoSettingContainer();
+
+          expect(successToast).toBeCalledTimes(1);
+          expect(reset).toBeCalledTimes(1);
+        });
+      });
     });
 
     describe('"이미지 선택" 버튼을 클릭하여 이미지를 업로드한다', () => {
@@ -258,6 +274,17 @@ describe('MyInfoSettingContainer', () => {
             ...FIXTURE_PROFILE,
             image: uploadProfileImageUrl,
           });
+        });
+      });
+
+      context('프로필 업데이트에 성공한 경우', () => {
+        given('isSuccessUpdate', () => true);
+
+        it('토스트 메시지가 호출되어야만 한다', () => {
+          renderMyInfoSettingContainer();
+
+          expect(successToast).toBeCalledTimes(1);
+          expect(reset).toBeCalledTimes(1);
         });
       });
     });

--- a/src/containers/myInfo/MyInfoSettingContainer.tsx
+++ b/src/containers/myInfo/MyInfoSettingContainer.tsx
@@ -16,8 +16,8 @@ import useReauthenticateWithProvider from '@/hooks/api/auth/useReauthenticateWit
 import useUpdateUser from '@/hooks/api/auth/useUpdateUser';
 import useDeleteStorageFile from '@/hooks/api/storage/useDeleteStorageFile';
 import useUploadStorageFile from '@/hooks/api/storage/useUploadStorageFile';
-import useRenderSuccessToast from '@/hooks/useRenderSuccessToast';
 import { DetailLayout } from '@/styles/Layout';
+import { successToast } from '@/utils/toast';
 
 function MyInfoSettingContainer(): ReactElement | null {
   const { replace } = useRouter();
@@ -29,15 +29,14 @@ function MyInfoSettingContainer(): ReactElement | null {
   const { mutate: deleteUser } = useAccountWithdrawal();
   const { mutate: deleteStorageUserImage } = useDeleteStorageFile();
   const {
-    data: profileImageUrl, mutate: uploadStorageUserImage, isSuccess: isSuccessUpload,
+    data: profileImageUrl, mutate: uploadStorageUserImage,
+    isSuccess: isSuccessUpload, reset: resetUploadStorage,
   } = useUploadStorageFile();
-  const { mutate: updateProfile, isSuccess: isSuccessUpdate } = useUpdateUser();
+  const {
+    mutate: updateProfile, isSuccess: isSuccessUpdate, reset: resetUpdateProfile,
+  } = useUpdateUser();
 
   const [imageActionType, setImageActionType] = useState<'삭제' | '수정'>();
-
-  useRenderSuccessToast(isSuccessUpdate, {
-    message: `이미지가 ${imageActionType}되었어요.`,
-  });
 
   const onWithdrawal = useCallback(() => {
     setIsReauthenticate(true);
@@ -84,14 +83,23 @@ function MyInfoSettingContainer(): ReactElement | null {
   }, [isReauthenticate, auth]);
 
   useEffect(() => {
-    if (isSuccessUpload && user) {
+    if (isSuccessUpload && profileImageUrl && user) {
       updateProfile({
         ...user,
         image: profileImageUrl,
       });
       setImageActionType('수정');
+      resetUploadStorage();
     }
   }, [isSuccessUpload, user, profileImageUrl]);
+
+  useEffect(() => {
+    if (isSuccessUpdate) {
+      successToast(`이미지가 ${imageActionType}되었어요.`);
+      setImageActionType(undefined);
+      resetUpdateProfile();
+    }
+  }, [isSuccessUpdate, imageActionType]);
 
   if (isLoading || !isSuccess) {
     return null;

--- a/src/hooks/api/auth/useUpdateUser.ts
+++ b/src/hooks/api/auth/useUpdateUser.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { AuthError } from 'firebase/auth';
+import { AuthError, User } from 'firebase/auth';
 
 import { Profile } from '@/models/auth';
 import { updateUserProfile } from '@/services/api/auth';
@@ -11,10 +11,10 @@ function useUpdateUser() {
 
   const mutation = useMutation<void, AuthError, Profile>((profile) => updateUserProfile(profile), {
     onSuccess: () => {
+      queryClient.setQueryData<User | null>(['authRedirectResult'], () => null);
+      queryClient.invalidateQueries(['token']);
       queryClient.invalidateQueries(['user']);
       queryClient.invalidateQueries(['profile']);
-      queryClient.invalidateQueries(['token']);
-      queryClient.invalidateQueries(['authRedirectResult']);
     },
   });
 


### PR DESCRIPTION
- 이미지 삭제 및 변경 api호출 후 query mutate 상태를 reset시켜줌으로 이전 값을 invalidate시켜주도록 수정