### PR TITLE
perf: 메인 페이지의 스터디 및 프로젝트 리스트에 concurrent mode를 적용하라

### DIFF
--- a/src/components/common/ClientOnly.test.tsx
+++ b/src/components/common/ClientOnly.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+
+import useIsMounted from '@/hooks/useIsMounted';
+
+import ClientOnly from './ClientOnly';
+
+jest.mock('@/hooks/useIsMounted');
+
+describe('ClientOnly', () => {
+  const child = '자식 컴포넌트';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useIsMounted as jest.Mock).mockImplementation(() => (given.isMounted));
+  });
+
+  const renderClientOnly = () => render((
+    <ClientOnly>
+      {child}
+    </ClientOnly>
+  ));
+
+  context('isMounted가 true인 경우', () => {
+    given('isMounted', () => true);
+
+    it('자식 컴포넌트가 나타나야만 한다', () => {
+      const { container } = renderClientOnly();
+
+      expect(container).toHaveTextContent(child);
+    });
+  });
+
+  context('isMounted가 false인 경우', () => {
+    given('isMounted', () => false);
+
+    it('아무것도 나타나지 않아야만 한다', () => {
+      const { container } = renderClientOnly();
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/src/components/common/ClientOnly.tsx
+++ b/src/components/common/ClientOnly.tsx
@@ -1,0 +1,17 @@
+import { PropsWithChildren, ReactElement } from 'react';
+
+import useIsMounted from '@/hooks/useIsMounted';
+
+function ClientOnly({ children }: PropsWithChildren): ReactElement | null {
+  const isMounted = useIsMounted();
+
+  if (!isMounted) {
+    return null;
+  }
+
+  return (
+    <>{children}</>
+  );
+}
+
+export default ClientOnly;

--- a/src/components/common/EmptyStateArea.tsx
+++ b/src/components/common/EmptyStateArea.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { memo, ReactElement } from 'react';
 
 import styled from '@emotion/styled';
 
@@ -45,7 +45,7 @@ function EmptyStateArea({
   );
 }
 
-export default EmptyStateArea;
+export default memo(EmptyStateArea);
 
 const EmptyStateWrapper = styled.section<{ marginTop: string; }>`
   display: flex;

--- a/src/components/home/RecruitPosts.test.tsx
+++ b/src/components/home/RecruitPosts.test.tsx
@@ -1,20 +1,27 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
+import useFetchGroups from '@/hooks/api/group/useFetchGroups';
+
 import GROUP_FIXTURE from '../../../fixtures/group';
 
 import RecruitPosts from './RecruitPosts';
+
+jest.mock('@/hooks/api/group/useFetchGroups');
 
 describe('RecruitPosts', () => {
   const handleClickEmptyButton = jest.fn();
 
   beforeEach(() => {
-    handleClickEmptyButton.mockClear();
+    jest.clearAllMocks();
+
+    (useFetchGroups as jest.Mock).mockImplementation(() => ({
+      data: given.groups,
+    }));
   });
 
   const renderRecruitPosts = () => render((
     <RecruitPosts
       onClickEmptyButton={handleClickEmptyButton}
-      groups={given.groups}
     />
   ));
 

--- a/src/components/home/RecruitPosts.tsx
+++ b/src/components/home/RecruitPosts.tsx
@@ -2,7 +2,7 @@ import React, { memo, ReactElement } from 'react';
 
 import styled from '@emotion/styled';
 
-import { Group } from '@/models/group';
+import useFetchGroups from '@/hooks/api/group/useFetchGroups';
 import { isEmpty } from '@/utils/utils';
 
 import EmptyFrameSvg from '../../assets/icons/empty-frame.svg';
@@ -11,11 +11,12 @@ import EmptyStateArea from '../common/EmptyStateArea';
 import RecruitPost from './RecruitPost';
 
 interface Props {
-  groups: Group[];
   onClickEmptyButton: () => void;
 }
 
-function RecruitPosts({ groups, onClickEmptyButton }: Props): ReactElement {
+function RecruitPosts({ onClickEmptyButton }: Props): ReactElement {
+  const { data: groups } = useFetchGroups();
+
   if (isEmpty(groups)) {
     return (
       <EmptyStateArea

--- a/src/containers/home/RecruitPostsContainer.test.tsx
+++ b/src/containers/home/RecruitPostsContainer.test.tsx
@@ -34,7 +34,6 @@ describe('RecruitPostsContainer', () => {
 
     (useFetchGroups as jest.Mock).mockImplementation(() => ({
       data: given.groups,
-      isLoading: given.isLoading,
     }));
 
     (useRouter as jest.Mock).mockImplementation(() => ({
@@ -48,23 +47,10 @@ describe('RecruitPostsContainer', () => {
 
   const renderRecruitPostsContainer = () => render((
     <InjectTestingRecoilState>
-      <>
-        <RecoilObserver node={signInModalVisibleState} onChange={handleSignInModalVisible} />
-        <RecruitPostsContainer />
-      </>
+      <RecoilObserver node={signInModalVisibleState} onChange={handleSignInModalVisible} />
+      <RecruitPostsContainer />
     </InjectTestingRecoilState>
   ));
-
-  context('로딩중인 경우', () => {
-    given('isLoading', () => true);
-    given('groups', () => []);
-
-    it('로딩 스켈레톤이 나타나야만 한다', () => {
-      renderRecruitPostsContainer();
-
-      expect(screen.getByTitle('loading...')).toBeInTheDocument();
-    });
-  });
 
   describe('신청현황 페이지에서 권한이 없어서 Redirect여부에 따라 메시지가 보인다', () => {
     given('groups', () => []);

--- a/src/containers/home/StatusBarContainer.tsx
+++ b/src/containers/home/StatusBarContainer.tsx
@@ -14,7 +14,7 @@ import { groupsConditionState } from '@/recoil/group/atom';
 import Divider from '@/styles/Divider';
 import { body1Font } from '@/styles/fontStyles';
 
-const TagsBar = dynamic(() => import('@/components/home/TagsBar'), { suspense: true });
+const TagsBar = dynamic(() => import('@/components/home/TagsBar'), { ssr: false });
 const SwitchButton = dynamic(() => import('@/components/common/SwitchButton'), { ssr: false });
 
 type FilterCondition = {

--- a/src/hooks/api/group/useFetchGroups.test.ts
+++ b/src/hooks/api/group/useFetchGroups.test.ts
@@ -1,7 +1,7 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 
 import { fetchGroups } from '@/services/api/group';
-import wrapper from '@/test/InjectMockProviders';
+import renderSuspenseHook from '@/test/renderSuspenseHook';
 
 import FIXTURE_GROUP from '../../../../fixtures/group';
 
@@ -10,7 +10,7 @@ import useFetchGroups from './useFetchGroups';
 jest.mock('@/services/api/group');
 
 describe('useFetchGroups', () => {
-  const useFetchGroupsHook = () => renderHook(() => useFetchGroups(), { wrapper });
+  const useFetchGroupsHook = () => renderSuspenseHook(useFetchGroups);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -21,7 +21,7 @@ describe('useFetchGroups', () => {
   given('groups', () => [FIXTURE_GROUP]);
 
   it('groups에 대한 정보를 반환해야만 한다', async () => {
-    const { result, waitFor } = useFetchGroupsHook();
+    const { result } = useFetchGroupsHook();
 
     await waitFor(() => result.current.isSuccess);
 

--- a/src/hooks/api/group/useFetchGroups.ts
+++ b/src/hooks/api/group/useFetchGroups.ts
@@ -12,7 +12,9 @@ import useCatchFirestoreErrorWithToast from '../useCatchFirestoreErrorWithToast'
 function useFetchGroups() {
   const groupsCondition = useRecoilValue(groupsConditionState);
 
-  const query = useQuery<Group[], FirestoreError>(['groups', groupsCondition], () => fetchGroups(groupsCondition));
+  const query = useQuery<Group[], FirestoreError>(['groups', groupsCondition], () => fetchGroups(groupsCondition), {
+    suspense: true,
+  });
 
   const { isError, error, data } = query;
 

--- a/src/hooks/api/tagsCount/useFetchTagsCount.test.ts
+++ b/src/hooks/api/tagsCount/useFetchTagsCount.test.ts
@@ -1,20 +1,14 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 
 import { getTagsCount } from '@/services/api/tagsCount';
-import ReactQueryWrapper from '@/test/ReactQueryWrapper';
+import renderSuspenseHook from '@/test/renderSuspenseHook';
 
 import useFetchTagsCount from './useFetchTagsCount';
 
 jest.mock('@/services/api/tagsCount');
 
 describe('useFetchTagsCount', () => {
-  const useFetchTagsCountHook = () => renderHook(() => useFetchTagsCount(), {
-    wrapper: ({ children }) => (
-      <ReactQueryWrapper suspense>
-        {children}
-      </ReactQueryWrapper>
-    ),
-  });
+  const useFetchTagsCountHook = () => renderSuspenseHook(useFetchTagsCount);
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/hooks/useIsMounted.test.ts
+++ b/src/hooks/useIsMounted.test.ts
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react';
+
+import useIsMounted from './useIsMounted';
+
+describe('useIsMounted', () => {
+  const useIsMountedHook = () => renderHook(useIsMounted);
+
+  it('mount가 된 경우 true를 반환해야만 한다', () => {
+    const { result } = useIsMountedHook();
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/hooks/useIsMounted.ts
+++ b/src/hooks/useIsMounted.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+
+function useIsMounted() {
+  const [mounted, setMounted] = useState<boolean>(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return mounted;
+}
+
+export default useIsMounted;

--- a/src/pages/index.test.tsx
+++ b/src/pages/index.test.tsx
@@ -4,6 +4,7 @@ import { act, render } from '@testing-library/react';
 
 import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useGetUser from '@/hooks/api/auth/useGetUser';
+import useFetchGroups from '@/hooks/api/group/useFetchGroups';
 import useFetchTagsCount from '@/hooks/api/tagsCount/useFetchTagsCount';
 import InjectMockProviders from '@/test/InjectMockProviders';
 
@@ -19,6 +20,7 @@ jest.mock('nanoid', () => ({
 jest.mock('@/hooks/api/auth/useGetUser');
 jest.mock('@/hooks/api/auth/useFetchUserProfile');
 jest.mock('@/hooks/api/tagsCount/useFetchTagsCount');
+jest.mock('@/hooks/api/group/useFetchGroups');
 
 describe('HomePage', () => {
   beforeEach(() => {
@@ -27,6 +29,10 @@ describe('HomePage', () => {
       query: {
         error: null,
       },
+    }));
+
+    (useFetchGroups as jest.Mock).mockImplementation(() => ({
+      data: [],
     }));
 
     (useGetUser as jest.Mock).mockImplementation(() => ({

--- a/src/test/renderSuspenseHook.tsx
+++ b/src/test/renderSuspenseHook.tsx
@@ -1,0 +1,17 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { renderHook } from '@testing-library/react';
+
+import InjectTestingRecoilState from './InjectTestingRecoilState';
+import ReactQueryWrapper from './ReactQueryWrapper';
+
+const renderSuspenseHook = <T, K>(render: (initialProps: K) => T) => renderHook<T, K>(render, {
+  wrapper: ({ children }) => (
+    <ReactQueryWrapper suspense>
+      <InjectTestingRecoilState>
+        {children}
+      </InjectTestingRecoilState>
+    </ReactQueryWrapper>
+  ),
+});
+
+export default renderSuspenseHook;


### PR DESCRIPTION
- dynamic import suspense 적용 및 fallback loading 적용
- ssr의 hydrate error를 방지하기 위해 useIsMounted hook 및 ClientOnly 컴포넌트 구현