### PR TITLE
feat: 내 정보 수정, 이미지 삭제, 이미지 수정시 api 호출이 발생했을 경우 로딩 처리를 적용하라

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react-intersection-observer": "^9.2.2",
     "react-responsive": "^9.0.0-beta.10",
     "react-select": "^5.3.1",
+    "react-spinners": "^0.13.6",
     "react-toastify": "^8.2.0",
     "react-toggle": "^4.1.2",
     "react-use": "^17.4.0",

--- a/src/components/common/Button.stories.tsx
+++ b/src/components/common/Button.stories.tsx
@@ -24,6 +24,7 @@ Default.args = {
   color: 'outlined',
   size: 'medium',
   disabled: false,
+  isLoading: false,
 };
 
 export const Success = Template.bind({});

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React, { HTMLProps, PropsWithChildren, ReactElement } from 'react';
+import FadeLoader from 'react-spinners/FadeLoader';
 
 import Link from 'next/link';
 
-import { css, Theme } from '@emotion/react';
+import { css, Theme, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { body1Font, body2Font, h4Font } from '@/styles/fontStyles';
@@ -14,6 +15,7 @@ type ButtonSize = 'small' | 'medium' | 'large';
 interface Props extends Omit<HTMLProps<HTMLButtonElement | HTMLAnchorElement>, 'size'> {
   color?: ColorType;
   size?: ButtonSize;
+  isLoading?: boolean;
 }
 
 interface StyledButtonProps {
@@ -23,8 +25,9 @@ interface StyledButtonProps {
 }
 
 function Button({
-  color = 'outlined', size = 'medium', href, children, type = 'button', ...rest
+  color = 'outlined', size = 'medium', href, children, type = 'button', isLoading = false, disabled, ...rest
 }: PropsWithChildren<Props>): ReactElement {
+  const theme = useTheme();
   const htmlProps = rest as any;
 
   if (href) {
@@ -46,8 +49,21 @@ function Button({
       color={color}
       size={size}
       type={type}
+      disabled={disabled || isLoading}
       {...htmlProps}
     >
+      <FadeLoader
+        height={size === 'large' ? 5.4 : 4}
+        margin={size === 'large' ? -11 : -12}
+        width={size === 'large' ? 2 : 1.6}
+        color={theme.accent4}
+        cssOverride={{
+          top: size === 'large' ? '18px' : '19px',
+          left: '21px',
+          marginRight: size === 'large' ? '8px' : '4px',
+        }}
+        loading={isLoading}
+      />
       {children}
     </StyledButton>
   );

--- a/src/components/myInfo/ImageSetting.test.tsx
+++ b/src/components/myInfo/ImageSetting.test.tsx
@@ -21,6 +21,8 @@ describe('ImageSetting', () => {
       imageUrl="/test"
       onUpload={handleUpload}
       onDelete={handleDelete}
+      isLoadingDeleteUserImage={false}
+      isLoadingUpload={false}
     />
   ));
 

--- a/src/components/myInfo/ImageSetting.tsx
+++ b/src/components/myInfo/ImageSetting.tsx
@@ -13,11 +13,15 @@ interface Props {
   imageUrl?: string | null;
   onDelete: () => void;
   onUpload: (image: File) => void;
+  isLoadingDeleteUserImage: boolean;
+  isLoadingUpload: boolean;
 }
 
 const IMAGE_MAX_SIZE = 5242880;
 
-function ImageSetting({ imageUrl, onDelete, onUpload }: Props):ReactElement {
+function ImageSetting({
+  imageUrl, onDelete, onUpload, isLoadingDeleteUserImage, isLoadingUpload,
+}: Props):ReactElement {
   const fileUploadInputRef = useRef<HTMLInputElement>(null);
 
   const handleClickSelectImage = () => fileUploadInputRef.current?.click();
@@ -41,6 +45,7 @@ function ImageSetting({ imageUrl, onDelete, onUpload }: Props):ReactElement {
       <Button
         size="small"
         color="primary"
+        isLoading={isLoadingUpload}
         onClick={handleClickSelectImage}
       >
         이미지 선택
@@ -57,6 +62,7 @@ function ImageSetting({ imageUrl, onDelete, onUpload }: Props):ReactElement {
         size="small"
         color="ghost"
         onClick={onDelete}
+        isLoading={isLoadingDeleteUserImage}
       >
         이미지 삭제
       </Button>

--- a/src/components/myInfo/SettingForm.test.tsx
+++ b/src/components/myInfo/SettingForm.test.tsx
@@ -27,6 +27,7 @@ describe('SettingForm', () => {
       }}
       onWithdrawal={handleWithdrawal}
       onSubmit={handleSubmit}
+      isLoading={false}
     />
   ));
 

--- a/src/components/myInfo/SettingForm.tsx
+++ b/src/components/myInfo/SettingForm.tsx
@@ -24,6 +24,7 @@ interface Props {
   user: Profile | null;
   onWithdrawal: () => void;
   onSubmit: (formData: SignUpAdditionalForm) => void;
+  isLoading: boolean;
 }
 
 const validationSchema = yup.object({
@@ -31,7 +32,9 @@ const validationSchema = yup.object({
   portfolioUrl: yup.string().trim().notRequired().nullable(),
 }).required();
 
-function SettingForm({ user, onWithdrawal, onSubmit }: Props): ReactElement {
+function SettingForm({
+  user, onWithdrawal, onSubmit, isLoading,
+}: Props): ReactElement {
   const {
     register, handleSubmit, formState: { isValid, errors, isDirty }, resetField, setValue,
   } = useForm<SignUpAdditionalForm>({
@@ -109,6 +112,7 @@ function SettingForm({ user, onWithdrawal, onSubmit }: Props): ReactElement {
           color="success"
           size="large"
           disabled={!isValid || !position || !isDirty}
+          isLoading={isLoading}
         >
           저장하기
         </Button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15224,6 +15224,11 @@ react-shallow-renderer@^16.15.0:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
 
+react-spinners@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/react-spinners/-/react-spinners-0.13.6.tgz#f97df4f7fedea7a496b391cf952761e13256610b"
+  integrity sha512-+VoSs1wN6oMhJy7PzCPiHUt6zUi9fvnGQizem8q/NzXhGovbdXFDWNhspk6KEKXQEafInUtpvtDlp/zJ5sES/A==
+
 react-syntax-highlighter@^15.4.5:
   version "15.5.0"
   resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.5.0.tgz#4b3eccc2325fa2ec8eff1e2d6c18fa4a9e07ab20"


### PR DESCRIPTION
- 버튼 공통 컴포넌트에 로딩 스피너 추가
- Install react-spinners dependency
- FadeLoader 사용
- 내 정보 수정, 이미지 삭제, 이미지 수정시 api 호출 후 로딩 중이면 버튼에 로딩 스피너가 나타나도록 수정
- 로딩 중인 경우 버튼 disabled