### PR TITLE
fix: ios에서 모집 마감일시 datepicker가 width 100%로 나오지 않는 이슈를 수정하라

### DIFF
--- a/src/components/write/PublishModalForm.tsx
+++ b/src/components/write/PublishModalForm.tsx
@@ -198,8 +198,6 @@ const DescriptionWrapper = styled.div`
 `;
 
 const RecruitmentEndDateInput = styled(Input)`
-  width: 100%;
-  position: relative;
   padding: 11px 7px 11px 16px;
 
   &:focus-within {

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -68,13 +68,14 @@ export const setGlobalStyles = (pathname: string, theme: Theme) => css`
   }
 
   input[type="datetime-local"] {
-    -webkit-appearance: textfield;
-    -moz-appearance: textfield;
+    display: block;
+    -webkit-appearance: none;
+    -moz-appearance: none;
   }
 
   input[type="date"] {
-    -webkit-appearance: textfield;
-    -moz-appearance: textfield;
+    -webkit-appearance: none;
+    -moz-appearance: none;
   }
 `;
 


### PR DESCRIPTION
- ios에서 모집 마감일시 datepicker가 width 100%로 나오지 않는 이슈를 수정