### PR TITLE
refactor: 내 정보 페이지의 모집합 팀 및 신청한 팀 리스트에 concurrent mode를 적용하라

### DIFF
--- a/src/containers/myInfo/AppliedGroupsContainer.test.tsx
+++ b/src/containers/myInfo/AppliedGroupsContainer.test.tsx
@@ -1,6 +1,6 @@
 import { createRef } from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useInfiniteFetchUserAppliedGroups from '@/hooks/api/group/useInfiniteFetchUserAppliedGroups';
@@ -22,8 +22,6 @@ describe('AppliedGroupsContainer', () => {
             items: [FIXTURE_GROUP],
           }],
         },
-        isLoading: given.isLoading,
-        fetchStatus: 'idle',
       },
       refState: {
         lastItemRef: jest.fn(),
@@ -39,21 +37,9 @@ describe('AppliedGroupsContainer', () => {
     <AppliedGroupsContainer />
   ));
 
-  context('로딩중인 경우', () => {
-    given('isLoading', () => true);
+  it('신청한 팀에 대한 리스트가 나타나야만 한다', () => {
+    const { container } = renderAppliedGroupsContainer();
 
-    it('로딩 스켈레톤이 나타나야만 한다', () => {
-      renderAppliedGroupsContainer();
-
-      expect(screen.getByTestId('skeleton-loader')).toBeInTheDocument();
-    });
-  });
-
-  context('로딩중이 아닌 경우', () => {
-    it('신청한 팀에 대한 리스트가 나타나야만 한다', () => {
-      const { container } = renderAppliedGroupsContainer();
-
-      expect(container).toHaveTextContent(FIXTURE_GROUP.title);
-    });
+    expect(container).toHaveTextContent(FIXTURE_GROUP.title);
   });
 });

--- a/src/containers/myInfo/AppliedGroupsContainer.tsx
+++ b/src/containers/myInfo/AppliedGroupsContainer.tsx
@@ -2,20 +2,15 @@ import React, { ReactElement } from 'react';
 
 import EmptyStateArea from '@/components/common/EmptyStateArea';
 import MyGroups from '@/components/myInfo/MyGroups';
-import MyGroupsSkeletonLoader from '@/components/myInfo/MyGroupsSkeletonLoader';
 import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useInfiniteFetchUserAppliedGroups from '@/hooks/api/group/useInfiniteFetchUserAppliedGroups';
 
 function AppliedGroupsContainer(): ReactElement {
-  const { data: user } = useFetchUserProfile();
+  const { data: user } = useFetchUserProfile({ suspense: true });
   const { query, refState } = useInfiniteFetchUserAppliedGroups({
     userUid: user?.uid,
     perPage: 10,
   });
-
-  if (query.isLoading && ['fetching', 'idle'].includes(query.fetchStatus)) {
-    return <MyGroupsSkeletonLoader />;
-  }
 
   return (
     <MyGroups

--- a/src/containers/myInfo/RecruitedGroupsContainer.test.tsx
+++ b/src/containers/myInfo/RecruitedGroupsContainer.test.tsx
@@ -1,6 +1,6 @@
 import { createRef } from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useInfiniteFetchUserRecruitedGroups from '@/hooks/api/group/useInfiniteFetchUserRecruitedGroups';
@@ -22,8 +22,6 @@ describe('RecruitedGroupsContainer', () => {
             items: [FIXTURE_GROUP],
           }],
         },
-        isLoading: given.isLoading,
-        fetchStatus: 'idle',
       },
       refState: {
         lastItemRef: jest.fn(),
@@ -39,23 +37,9 @@ describe('RecruitedGroupsContainer', () => {
     <RecruitedGroupsContainer />
   ));
 
-  context('로딩중인 경우', () => {
-    given('isLoading', () => true);
+  it('모집한 팀에 대한 리스트가 나타나야만 한다', () => {
+    const { container } = renderRecruitedGroupsContainer();
 
-    it('로딩 스켈레톤이 나타나야만 한다', () => {
-      renderRecruitedGroupsContainer();
-
-      expect(screen.getByTestId('skeleton-loader')).toBeInTheDocument();
-    });
-  });
-
-  context('로딩중이 아닌 경우', () => {
-    given('isLoading', () => false);
-
-    it('모집한 팀에 대한 리스트가 나타나야만 한다', () => {
-      const { container } = renderRecruitedGroupsContainer();
-
-      expect(container).toHaveTextContent(FIXTURE_GROUP.title);
-    });
+    expect(container).toHaveTextContent(FIXTURE_GROUP.title);
   });
 });

--- a/src/containers/myInfo/RecruitedGroupsContainer.tsx
+++ b/src/containers/myInfo/RecruitedGroupsContainer.tsx
@@ -2,20 +2,15 @@ import React, { ReactElement } from 'react';
 
 import EmptyStateArea from '@/components/common/EmptyStateArea';
 import MyGroups from '@/components/myInfo/MyGroups';
-import MyGroupsSkeletonLoader from '@/components/myInfo/MyGroupsSkeletonLoader';
 import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useInfiniteFetchUserRecruitedGroups from '@/hooks/api/group/useInfiniteFetchUserRecruitedGroups';
 
 function RecruitedGroupsContainer(): ReactElement {
-  const { data: user } = useFetchUserProfile();
+  const { data: user } = useFetchUserProfile({ suspense: true });
   const { query, refState } = useInfiniteFetchUserRecruitedGroups({
     userUid: user?.uid,
     perPage: 10,
   });
-
-  if (query.isLoading && ['fetching', 'idle'].includes(query.fetchStatus)) {
-    return <MyGroupsSkeletonLoader />;
-  }
 
   return (
     <MyGroups

--- a/src/hooks/api/auth/useFetchUserProfile.ts
+++ b/src/hooks/api/auth/useFetchUserProfile.ts
@@ -8,11 +8,12 @@ import useCatchFirestoreErrorWithToast from '../useCatchFirestoreErrorWithToast'
 
 import useGetUser from './useGetUser';
 
-function useFetchUserProfile() {
-  const { data: user, isLoading } = useGetUser();
+function useFetchUserProfile({ suspense }: { suspense?: boolean } = {}) {
+  const { data: user, isLoading } = useGetUser({ suspense });
 
   const query = useQuery<Profile | null, FirestoreError>(['profile'], () => getUserProfile(user?.uid), {
     enabled: !!user?.uid,
+    suspense,
   });
 
   const { isError, error } = query;

--- a/src/hooks/api/auth/useGetUser.ts
+++ b/src/hooks/api/auth/useGetUser.ts
@@ -2,8 +2,10 @@ import { firebaseAuth } from '@/services/firebase';
 
 import useAuthUser from './useAuthUser';
 
-function useGetUser() {
-  const user = useAuthUser(['user'], firebaseAuth);
+function useGetUser({ suspense }: { suspense?: boolean } = {}) {
+  const user = useAuthUser(['user'], firebaseAuth, {
+    suspense,
+  });
 
   return {
     ...user,

--- a/src/hooks/api/group/useInfiniteFetchUserAppliedGroups.test.ts
+++ b/src/hooks/api/group/useInfiniteFetchUserAppliedGroups.test.ts
@@ -1,9 +1,9 @@
 import { useInView } from 'react-intersection-observer';
 
-import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 
 import { getUserAppliedGroups } from '@/services/api/applicants';
-import wrapper from '@/test/ReactQueryWrapper';
+import renderSuspenseHook from '@/test/renderSuspenseHook';
 
 import FIXTURE_GROUP from '../../../../fixtures/group';
 
@@ -17,9 +17,8 @@ describe('useInfiniteFetchUserAppliedGroups', () => {
     lastUid: '1',
   };
 
-  const useInfiniteFetchUserAppliedGroupsHook = () => renderHook(
+  const useInfiniteFetchUserAppliedGroupsHook = () => renderSuspenseHook(
     () => useInfiniteFetchUserAppliedGroups({ perPage: 10, userUid: 'userUid' }),
-    { wrapper },
   );
 
   beforeEach(() => {
@@ -34,7 +33,7 @@ describe('useInfiniteFetchUserAppliedGroups', () => {
   });
 
   it('getUserAppliedGroups를 한 번 호출 후 반환해야만 한다', async () => {
-    const { result, waitFor } = useInfiniteFetchUserAppliedGroupsHook();
+    const { result } = useInfiniteFetchUserAppliedGroupsHook();
 
     await waitFor(() => result.current.query.isSuccess);
 

--- a/src/hooks/api/group/useInfiniteFetchUserAppliedGroups.ts
+++ b/src/hooks/api/group/useInfiniteFetchUserAppliedGroups.ts
@@ -25,6 +25,7 @@ function useInfiniteFetchUserAppliedGroups({ userUid, perPage }: UserAppliedGrou
     {
       getNextPageParam: ({ lastUid }) => lastUid,
       enabled: !!userUid && !!perPage,
+      suspense: true,
     },
   );
 

--- a/src/hooks/api/group/useInfiniteFetchUserRecruitedGroups.test.ts
+++ b/src/hooks/api/group/useInfiniteFetchUserRecruitedGroups.test.ts
@@ -1,9 +1,9 @@
 import { useInView } from 'react-intersection-observer';
 
-import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 
 import { getUserRecruitedGroups } from '@/services/api/group';
-import wrapper from '@/test/ReactQueryWrapper';
+import renderSuspenseHook from '@/test/renderSuspenseHook';
 
 import FIXTURE_GROUP from '../../../../fixtures/group';
 
@@ -17,9 +17,8 @@ describe('useInfiniteFetchUserRecruitedGroups', () => {
     lastUid: '1',
   };
 
-  const useInfiniteFetchUserRecruitedGroupsHook = () => renderHook(
+  const useInfiniteFetchUserRecruitedGroupsHook = () => renderSuspenseHook(
     () => useInfiniteFetchUserRecruitedGroups({ perPage: 10, userUid: 'userUid' }),
-    { wrapper },
   );
 
   beforeEach(() => {
@@ -34,7 +33,7 @@ describe('useInfiniteFetchUserRecruitedGroups', () => {
   });
 
   it('getUserRecruitedGroups를 한 번 호출 후 반환해야만 한다', async () => {
-    const { result, waitFor } = useInfiniteFetchUserRecruitedGroupsHook();
+    const { result } = useInfiniteFetchUserRecruitedGroupsHook();
 
     await waitFor(() => result.current.query.isSuccess);
 

--- a/src/hooks/api/group/useInfiniteFetchUserRecruitedGroups.ts
+++ b/src/hooks/api/group/useInfiniteFetchUserRecruitedGroups.ts
@@ -25,6 +25,7 @@ function useInfiniteFetchUserRecruitedGroups({ userUid, perPage }: UserRecruited
     {
       getNextPageParam: ({ lastUid }) => lastUid,
       enabled: !!userUid && !!perPage,
+      suspense: true,
     },
   );
 

--- a/src/pages/myinfo/applied.page.tsx
+++ b/src/pages/myinfo/applied.page.tsx
@@ -1,11 +1,15 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, Suspense } from 'react';
 
 import { GetServerSideProps } from 'next';
+import dynamic from 'next/dynamic';
 import { NextSeo } from 'next-seo';
 
+import ClientOnly from '@/components/common/ClientOnly';
+import MyGroupsSkeletonLoader from '@/components/myInfo/MyGroupsSkeletonLoader';
 import getMyInfoLayout from '@/components/myInfo/MyInfoLayout';
-import AppliedGroupsContainer from '@/containers/myInfo/AppliedGroupsContainer';
 import authenticatedServerSideProps from '@/services/serverSideProps/authenticatedServerSideProps';
+
+const AppliedGroupsContainer = dynamic(() => import('@/containers/myInfo/AppliedGroupsContainer'), { suspense: true });
 
 export const getServerSideProps: GetServerSideProps = authenticatedServerSideProps;
 
@@ -19,7 +23,11 @@ function AppliedPage(): ReactElement {
           url: `${process.env.NEXT_PUBLIC_ORIGIN}/myinfo/applied`,
         }}
       />
-      <AppliedGroupsContainer />
+      <ClientOnly>
+        <Suspense fallback={<MyGroupsSkeletonLoader />}>
+          <AppliedGroupsContainer />
+        </Suspense>
+      </ClientOnly>
     </>
   );
 }

--- a/src/pages/myinfo/applied.test.tsx
+++ b/src/pages/myinfo/applied.test.tsx
@@ -28,8 +28,6 @@ describe('AppliedPage', () => {
             items: [FIXTURE_GROUP],
           }],
         },
-        isLoading: given.isLoading,
-        isIdle: false,
       },
       refState: {
         lastItemRef: jest.fn(),

--- a/src/pages/myinfo/recruited.page.tsx
+++ b/src/pages/myinfo/recruited.page.tsx
@@ -1,11 +1,15 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, Suspense } from 'react';
 
 import { GetServerSideProps } from 'next';
+import dynamic from 'next/dynamic';
 import { NextSeo } from 'next-seo';
 
+import ClientOnly from '@/components/common/ClientOnly';
+import MyGroupsSkeletonLoader from '@/components/myInfo/MyGroupsSkeletonLoader';
 import getMyInfoLayout from '@/components/myInfo/MyInfoLayout';
-import RecruitedGroupsContainer from '@/containers/myInfo/RecruitedGroupsContainer';
 import authenticatedServerSideProps from '@/services/serverSideProps/authenticatedServerSideProps';
+
+const RecruitedGroupsContainer = dynamic(() => import('@/containers/myInfo/RecruitedGroupsContainer'), { suspense: true });
 
 export const getServerSideProps: GetServerSideProps = authenticatedServerSideProps;
 
@@ -19,7 +23,11 @@ function RecruitedPage(): ReactElement {
           url: `${process.env.NEXT_PUBLIC_ORIGIN}/myinfo/recruited`,
         }}
       />
-      <RecruitedGroupsContainer />
+      <ClientOnly>
+        <Suspense fallback={<MyGroupsSkeletonLoader />}>
+          <RecruitedGroupsContainer />
+        </Suspense>
+      </ClientOnly>
     </>
   );
 }

--- a/src/pages/myinfo/recruited.test.tsx
+++ b/src/pages/myinfo/recruited.test.tsx
@@ -23,8 +23,6 @@ describe('RecruitedPage', () => {
             items: [FIXTURE_GROUP],
           }],
         },
-        isLoading: given.isLoading,
-        isIdle: false,
       },
       refState: {
         lastItemRef: jest.fn(),


### PR DESCRIPTION
- 내 정보 페이지의 모집합 팀 및 신청한 팀 리스트에 concurrent mode를 적용
- useFetchProfile과 useGetUser api hook에 suspense 적용