### PR TITLE
feat(ErrorBoundary): suspense를 사용중인 컴포넌트에 errorBoundary를 적용하라

### DIFF
--- a/src/components/applicants/ApplicationStatus.tsx
+++ b/src/components/applicants/ApplicationStatus.tsx
@@ -17,7 +17,7 @@ import ApplicantItem from './ApplicantItem';
 
 function ApplicationStatus(): ReactElement {
   const { query, back } = useRouter();
-  const { data: applicants } = useFetchApplicants({ suspense: true });
+  const { data: applicants } = useFetchApplicants({ suspense: true, useErrorBoundary: true });
   const { mutate } = useUpdateApplicant();
 
   const onToggleConfirm = useCallback((applicant: Applicant) => mutate({

--- a/src/containers/alarm/AlarmListContainer.tsx
+++ b/src/containers/alarm/AlarmListContainer.tsx
@@ -6,7 +6,7 @@ import useUpdateAlarmViewed from '@/hooks/api/alarm/useUpdateAlarmViewed';
 import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 
 function AlarmListContainer(): ReactElement {
-  const { data: user } = useFetchUserProfile({ suspense: true });
+  const { data: user } = useFetchUserProfile({ suspense: true, useErrorBoundary: true });
   const { query, refState } = useInfiniteFetchAlarms({ userUid: user?.uid });
   const { mutate: updateAlarm } = useUpdateAlarmViewed();
 

--- a/src/containers/applicants/ApplicationStatusContainer.tsx
+++ b/src/containers/applicants/ApplicationStatusContainer.tsx
@@ -6,6 +6,7 @@ import styled from '@emotion/styled';
 
 import ApplicationStatusSkeletonLoader from '@/components/applicants/ApplicationStatusSkeletonLoader';
 import ClientOnly from '@/components/common/ClientOnly';
+import ErrorBoundary from '@/components/common/ErrorBoundary';
 import useResponsive from '@/hooks/useResponsive';
 import GradientBlock from '@/styles/GradientBlock';
 import { DetailLayout } from '@/styles/Layout';
@@ -19,9 +20,11 @@ function ApplicationStatusContainer(): ReactElement {
   return (
     <ClientOnly>
       <ApplicationStatusDetailLayout>
-        <Suspense fallback={<ApplicationStatusSkeletonLoader isMobile={isMobile} />}>
-          <ApplicationStatus />
-        </Suspense>
+        <ErrorBoundary errorMessage="해당 글의 신청자 정보를 불러오는데 실패했어요!">
+          <Suspense fallback={<ApplicationStatusSkeletonLoader isMobile={isMobile} />}>
+            <ApplicationStatus />
+          </Suspense>
+        </ErrorBoundary>
         {isMobile && (
           <GradientBlock data-testid="gradient-block" />
         )}

--- a/src/containers/detail/CommentsContainer.tsx
+++ b/src/containers/detail/CommentsContainer.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
 
 import ClientOnly from '@/components/common/ClientOnly';
+import ErrorBoundary from '@/components/common/ErrorBoundary';
 import CommentForm from '@/components/detail/CommentForm';
 import CommentSkeletonLoader from '@/components/detail/CommentSkeletonLoader';
 import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
@@ -46,13 +47,15 @@ function CommentsContainer(): ReactElement {
         onSubmit={onSubmit}
       />
       <ClientOnly>
-        <Suspense fallback={<CommentSkeletonLoader />}>
-          <CommentsView
-            user={user}
-            perPage={perPage}
-            onRemove={onRemoveComment}
-          />
-        </Suspense>
+        <ErrorBoundary errorMessage="댓글을 불러오는데 실패하였습니다.">
+          <Suspense fallback={<CommentSkeletonLoader />}>
+            <CommentsView
+              user={user}
+              perPage={perPage}
+              onRemove={onRemoveComment}
+            />
+          </Suspense>
+        </ErrorBoundary>
       </ClientOnly>
     </>
   );

--- a/src/containers/myInfo/AppliedGroupsContainer.tsx
+++ b/src/containers/myInfo/AppliedGroupsContainer.tsx
@@ -6,7 +6,7 @@ import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useInfiniteFetchUserAppliedGroups from '@/hooks/api/group/useInfiniteFetchUserAppliedGroups';
 
 function AppliedGroupsContainer(): ReactElement {
-  const { data: user } = useFetchUserProfile({ suspense: true });
+  const { data: user } = useFetchUserProfile({ suspense: true, useErrorBoundary: true });
   const { query, refState } = useInfiniteFetchUserAppliedGroups({
     userUid: user?.uid,
     perPage: 10,

--- a/src/containers/myInfo/RecruitedGroupsContainer.tsx
+++ b/src/containers/myInfo/RecruitedGroupsContainer.tsx
@@ -6,7 +6,7 @@ import useFetchUserProfile from '@/hooks/api/auth/useFetchUserProfile';
 import useInfiniteFetchUserRecruitedGroups from '@/hooks/api/group/useInfiniteFetchUserRecruitedGroups';
 
 function RecruitedGroupsContainer(): ReactElement {
-  const { data: user } = useFetchUserProfile({ suspense: true });
+  const { data: user } = useFetchUserProfile({ suspense: true, useErrorBoundary: true });
   const { query, refState } = useInfiniteFetchUserRecruitedGroups({
     userUid: user?.uid,
     perPage: 10,

--- a/src/hooks/api/alarm/useInfiniteFetchAlarms.ts
+++ b/src/hooks/api/alarm/useInfiniteFetchAlarms.ts
@@ -21,6 +21,7 @@ function useInfiniteFetchAlarms({ userUid }: { userUid?: string }) {
     getNextPageParam: ({ lastUid }) => lastUid,
     enabled: !!userUid,
     suspense: true,
+    useErrorBoundary: true,
   });
 
   const {

--- a/src/hooks/api/alarm/useInfiniteFetchAlarms.ts
+++ b/src/hooks/api/alarm/useInfiniteFetchAlarms.ts
@@ -9,8 +9,6 @@ import { Alarm } from '@/models/alarm';
 import { getUserAlarms } from '@/services/api/alarm';
 import { checkEmpty } from '@/utils/utils';
 
-import useCatchFirestoreErrorWithToast from '../useCatchFirestoreErrorWithToast';
-
 function useInfiniteFetchAlarms({ userUid }: { userUid?: string }) {
   const query = useInfiniteQuery<InfiniteResponse<Alarm>, FirestoreError>(['alarms'], ({
     pageParam,
@@ -24,15 +22,7 @@ function useInfiniteFetchAlarms({ userUid }: { userUid?: string }) {
     useErrorBoundary: true,
   });
 
-  const {
-    isError, error, hasNextPage, fetchNextPage,
-  } = query;
-
-  useCatchFirestoreErrorWithToast({
-    isError,
-    error,
-    defaultErrorMessage: '알람을 불러오는데 실패했어요!',
-  });
+  const { hasNextPage, fetchNextPage } = query;
 
   const refState = useIntersectionObserver<HTMLAnchorElement>({
     intersectionOptions: {

--- a/src/hooks/api/applicant/useFetchApplicants.ts
+++ b/src/hooks/api/applicant/useFetchApplicants.ts
@@ -10,7 +10,9 @@ import { checkEmpty } from '@/utils/utils';
 
 import useCatchFirestoreErrorWithToast from '../useCatchFirestoreErrorWithToast';
 
-function useFetchApplicants({ suspense }: { suspense: boolean; }) {
+function useFetchApplicants({
+  suspense, useErrorBoundary = false,
+}: { suspense: boolean; useErrorBoundary?: boolean; }) {
   const router = useRouter();
 
   const { id } = router.query as GroupQuery;
@@ -18,6 +20,7 @@ function useFetchApplicants({ suspense }: { suspense: boolean; }) {
   const query = useQuery<Applicant[], FirestoreError>(['applicants', id], () => getApplicants(id), {
     enabled: !!id,
     suspense,
+    useErrorBoundary,
   });
 
   const { isError, error, data } = query;

--- a/src/hooks/api/auth/useFetchUserProfile.ts
+++ b/src/hooks/api/auth/useFetchUserProfile.ts
@@ -8,12 +8,15 @@ import useCatchFirestoreErrorWithToast from '../useCatchFirestoreErrorWithToast'
 
 import useGetUser from './useGetUser';
 
-function useFetchUserProfile({ suspense }: { suspense?: boolean } = {}) {
+function useFetchUserProfile({
+  suspense, useErrorBoundary = false,
+}: { suspense?: boolean; useErrorBoundary?: boolean; } = {}) {
   const { data: user, isLoading } = useGetUser({ suspense });
 
   const query = useQuery<Profile | null, FirestoreError>(['profile'], () => getUserProfile(user?.uid), {
     enabled: !!user?.uid,
     suspense,
+    useErrorBoundary,
   });
 
   const { isError, error } = query;

--- a/src/hooks/api/auth/useGetUser.ts
+++ b/src/hooks/api/auth/useGetUser.ts
@@ -2,9 +2,12 @@ import { firebaseAuth } from '@/services/firebase';
 
 import useAuthUser from './useAuthUser';
 
-function useGetUser({ suspense }: { suspense?: boolean } = {}) {
+function useGetUser({
+  suspense, useErrorBoundary = false,
+}: { suspense?: boolean; useErrorBoundary?: boolean; } = {}) {
   const user = useAuthUser(['user'], firebaseAuth, {
     suspense,
+    useErrorBoundary,
   });
 
   return {

--- a/src/hooks/api/comment/useInfiniteFetchComments.ts
+++ b/src/hooks/api/comment/useInfiniteFetchComments.ts
@@ -28,6 +28,7 @@ function useInfiniteFetchComments({ perPage }: InfiniteRequest) {
       getNextPageParam: ({ lastUid }) => lastUid,
       enabled: !!id && !!perPage,
       suspense: true,
+      useErrorBoundary: true,
     },
   );
 

--- a/src/hooks/api/comment/useInfiniteFetchComments.ts
+++ b/src/hooks/api/comment/useInfiniteFetchComments.ts
@@ -11,8 +11,6 @@ import { Comment } from '@/models/group';
 import { getGroupComments } from '@/services/api/comment';
 import { checkEmpty } from '@/utils/utils';
 
-import useCatchFirestoreErrorWithToast from '../useCatchFirestoreErrorWithToast';
-
 function useInfiniteFetchComments({ perPage }: InfiniteRequest) {
   const router = useRouter();
 
@@ -32,15 +30,7 @@ function useInfiniteFetchComments({ perPage }: InfiniteRequest) {
     },
   );
 
-  const {
-    isError, error, hasNextPage, fetchNextPage,
-  } = query;
-
-  useCatchFirestoreErrorWithToast({
-    isError,
-    error,
-    defaultErrorMessage: '해당 글의 댓글을 불러오는데 실패하였습니다.',
-  });
+  const { hasNextPage, fetchNextPage } = query;
 
   const refState = useIntersectionObserver<HTMLDivElement>({
     intersectionOptions: {

--- a/src/hooks/api/group/useInfiniteFetchUserAppliedGroups.ts
+++ b/src/hooks/api/group/useInfiniteFetchUserAppliedGroups.ts
@@ -9,8 +9,6 @@ import { Group } from '@/models/group';
 import { getUserAppliedGroups } from '@/services/api/applicants';
 import { checkEmpty } from '@/utils/utils';
 
-import useCatchFirestoreErrorWithToast from '../useCatchFirestoreErrorWithToast';
-
 interface UserAppliedGroupsRequest extends InfiniteRequest {
   userUid?: string;
 }
@@ -30,15 +28,7 @@ function useInfiniteFetchUserAppliedGroups({ userUid, perPage }: UserAppliedGrou
     },
   );
 
-  const {
-    error, isError, hasNextPage, fetchNextPage,
-  } = query;
-
-  useCatchFirestoreErrorWithToast({
-    error,
-    isError,
-    defaultErrorMessage: '신청한 팀을 불러오는데 실패했어요!',
-  });
+  const { hasNextPage, fetchNextPage } = query;
 
   const refState = useIntersectionObserver<HTMLAnchorElement>({
     intersectionOptions: {

--- a/src/hooks/api/group/useInfiniteFetchUserAppliedGroups.ts
+++ b/src/hooks/api/group/useInfiniteFetchUserAppliedGroups.ts
@@ -26,6 +26,7 @@ function useInfiniteFetchUserAppliedGroups({ userUid, perPage }: UserAppliedGrou
       getNextPageParam: ({ lastUid }) => lastUid,
       enabled: !!userUid && !!perPage,
       suspense: true,
+      useErrorBoundary: true,
     },
   );
 

--- a/src/hooks/api/group/useInfiniteFetchUserRecruitedGroups.ts
+++ b/src/hooks/api/group/useInfiniteFetchUserRecruitedGroups.ts
@@ -26,6 +26,7 @@ function useInfiniteFetchUserRecruitedGroups({ userUid, perPage }: UserRecruited
       getNextPageParam: ({ lastUid }) => lastUid,
       enabled: !!userUid && !!perPage,
       suspense: true,
+      useErrorBoundary: true,
     },
   );
 

--- a/src/hooks/api/group/useInfiniteFetchUserRecruitedGroups.ts
+++ b/src/hooks/api/group/useInfiniteFetchUserRecruitedGroups.ts
@@ -9,8 +9,6 @@ import { Group } from '@/models/group';
 import { getUserRecruitedGroups } from '@/services/api/group';
 import { checkEmpty } from '@/utils/utils';
 
-import useCatchFirestoreErrorWithToast from '../useCatchFirestoreErrorWithToast';
-
 interface UserRecruitedGroupsRequest extends InfiniteRequest {
   userUid?: string;
 }
@@ -30,15 +28,7 @@ function useInfiniteFetchUserRecruitedGroups({ userUid, perPage }: UserRecruited
     },
   );
 
-  const {
-    error, isError, hasNextPage, fetchNextPage,
-  } = query;
-
-  useCatchFirestoreErrorWithToast({
-    error,
-    isError,
-    defaultErrorMessage: '모집한 팀을 불러오는데 실패했어요!',
-  });
+  const { hasNextPage, fetchNextPage } = query;
 
   const refState = useIntersectionObserver<HTMLAnchorElement>({
     intersectionOptions: {

--- a/src/pages/alarm.page.tsx
+++ b/src/pages/alarm.page.tsx
@@ -6,6 +6,7 @@ import { NextSeo } from 'next-seo';
 
 import AlarmsSkeletonLoader from '@/components/alarm/AlarmsSkeletonLoader';
 import ClientOnly from '@/components/common/ClientOnly';
+import ErrorBoundary from '@/components/common/ErrorBoundary';
 import HeaderContainer from '@/containers/common/HeaderContainer';
 import authenticatedServerSideProps from '@/services/serverSideProps/authenticatedServerSideProps';
 import { DetailLayout } from '@/styles/Layout';
@@ -27,9 +28,11 @@ function AlarmPage(): ReactElement {
       <HeaderContainer />
       <DetailLayout>
         <ClientOnly>
-          <Suspense fallback={<AlarmsSkeletonLoader />}>
-            <AlarmListContainer />
-          </Suspense>
+          <ErrorBoundary errorMessage="알람을 불러오는데 실패했어요!">
+            <Suspense fallback={<AlarmsSkeletonLoader />}>
+              <AlarmListContainer />
+            </Suspense>
+          </ErrorBoundary>
         </ClientOnly>
       </DetailLayout>
     </>

--- a/src/pages/myinfo/applied.page.tsx
+++ b/src/pages/myinfo/applied.page.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 import { NextSeo } from 'next-seo';
 
 import ClientOnly from '@/components/common/ClientOnly';
+import ErrorBoundary from '@/components/common/ErrorBoundary';
 import MyGroupsSkeletonLoader from '@/components/myInfo/MyGroupsSkeletonLoader';
 import getMyInfoLayout from '@/components/myInfo/MyInfoLayout';
 import authenticatedServerSideProps from '@/services/serverSideProps/authenticatedServerSideProps';
@@ -24,9 +25,11 @@ function AppliedPage(): ReactElement {
         }}
       />
       <ClientOnly>
-        <Suspense fallback={<MyGroupsSkeletonLoader />}>
-          <AppliedGroupsContainer />
-        </Suspense>
+        <ErrorBoundary errorMessage="신청한 팀을 불러오는데 실패했어요!">
+          <Suspense fallback={<MyGroupsSkeletonLoader />}>
+            <AppliedGroupsContainer />
+          </Suspense>
+        </ErrorBoundary>
       </ClientOnly>
     </>
   );

--- a/src/pages/myinfo/applied.test.tsx
+++ b/src/pages/myinfo/applied.test.tsx
@@ -10,6 +10,11 @@ import FIXTURE_GROUP from '../../../fixtures/group';
 
 import AppliedPage, { getServerSideProps } from './applied.page';
 
+jest.mock('next/router', () => ({
+  useRouter: jest.fn().mockImplementation(() => ({
+    replace: jest.fn(),
+  })),
+}));
 jest.mock('@/hooks/api/group/useInfiniteFetchUserAppliedGroups');
 jest.mock('@/hooks/api/auth/useFetchUserProfile');
 jest.mock('@/services/serverSideProps/authenticatedServerSideProps');

--- a/src/pages/myinfo/recruited.page.tsx
+++ b/src/pages/myinfo/recruited.page.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 import { NextSeo } from 'next-seo';
 
 import ClientOnly from '@/components/common/ClientOnly';
+import ErrorBoundary from '@/components/common/ErrorBoundary';
 import MyGroupsSkeletonLoader from '@/components/myInfo/MyGroupsSkeletonLoader';
 import getMyInfoLayout from '@/components/myInfo/MyInfoLayout';
 import authenticatedServerSideProps from '@/services/serverSideProps/authenticatedServerSideProps';
@@ -24,9 +25,11 @@ function RecruitedPage(): ReactElement {
         }}
       />
       <ClientOnly>
-        <Suspense fallback={<MyGroupsSkeletonLoader />}>
-          <RecruitedGroupsContainer />
-        </Suspense>
+        <ErrorBoundary errorMessage="모집한 팀을 불러오는데 실패했어요!">
+          <Suspense fallback={<MyGroupsSkeletonLoader />}>
+            <RecruitedGroupsContainer />
+          </Suspense>
+        </ErrorBoundary>
       </ClientOnly>
     </>
   );

--- a/src/pages/myinfo/recruited.test.tsx
+++ b/src/pages/myinfo/recruited.test.tsx
@@ -10,6 +10,11 @@ import FIXTURE_GROUP from '../../../fixtures/group';
 
 import RecruitedPage, { getServerSideProps } from './recruited.page';
 
+jest.mock('next/router', () => ({
+  useRouter: jest.fn().mockImplementation(() => ({
+    replace: jest.fn(),
+  })),
+}));
 jest.mock('@/hooks/api/group/useInfiniteFetchUserRecruitedGroups');
 jest.mock('@/hooks/api/auth/useFetchUserProfile');
 jest.mock('@/services/serverSideProps/authenticatedServerSideProps');


### PR DESCRIPTION
- 신청자 리스트 페이지에 errorBoundary 적용
- 알람 리스트에 ErrorBoundary 적용
- 글 댓글 리스트에 ErrorBoundary 적용
- 내 신청한 팀 리스트에 errorBoundary 적용
- 사용자 정보를 가져오는 api hook을 ErrorBoundary사용할 수 있게끔 리팩터링
- 내 모집한 팀 리스트에 ErrorBoundary 적용
- useErrorBoundary 옵션이 true인 react-query api hook인 경우 catch error hook 삭제