### PR TITLE
refactor(TagsBarSkeletonLoader): list item에서 사용중인 nanoid를 삭제하라

### DIFF
--- a/src/components/home/skeleton/TagsBarSkeletonLoader.test.tsx
+++ b/src/components/home/skeleton/TagsBarSkeletonLoader.test.tsx
@@ -2,10 +2,6 @@ import { render, screen } from '@testing-library/react';
 
 import TagsBarSkeletonLoader from './TagsBarSkeletonLoader';
 
-jest.mock('nanoid', () => ({
-  nanoid: jest.fn().mockImplementation(() => Math.random()),
-}));
-
 describe('TagsBarSkeletonLoader', () => {
   const renderTagsBarSkeletonLoader = () => render((
     <TagsBarSkeletonLoader />

--- a/src/components/home/skeleton/TagsBarSkeletonLoader.tsx
+++ b/src/components/home/skeleton/TagsBarSkeletonLoader.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 
 import styled from '@emotion/styled';
-import { nanoid } from 'nanoid';
 
 import SkeletonItem from '@/components/common/SkeletonItem';
 
 function TagsBarSkeletonLoader() {
   return (
     <TagsBarSkeletonLoaderWrapper title="loading..." data-testid="loading-skeleton">
-      {['80px', '120px', '80px', '80px', '120px', '64px'].map((width) => (
+      {['80px', '120px', '80px', '80px', '120px', '64px'].map((width, index) => (
         <SkeletonItem
-          key={nanoid()}
+          // eslint-disable-next-line react/no-array-index-key
+          key={index} // NOTE - 변경될 가능성도 없고, 항상 고정되어있는 배열이고 인덱스 번호도 고정이기 때문에 index 사용
           styles={{
             height: '36px',
             width,

--- a/src/containers/home/StatusBarContainer.test.tsx
+++ b/src/containers/home/StatusBarContainer.test.tsx
@@ -18,9 +18,6 @@ jest.mock('react-toastify', () => ({
     error: jest.fn(),
   },
 }));
-jest.mock('nanoid', () => ({
-  nanoid: jest.fn().mockImplementation(() => Math.random()),
-}));
 
 describe('StatusBarContainer', () => {
   beforeEach(() => {

--- a/src/pages/index.test.tsx
+++ b/src/pages/index.test.tsx
@@ -15,10 +15,6 @@ import HomePage from './index.page';
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
 }));
-jest.mock('nanoid', () => ({
-  nanoid: jest.fn().mockImplementation(() => Math.random()),
-}));
-
 jest.mock('@/hooks/api/auth/useGetUser');
 jest.mock('@/hooks/api/auth/useFetchUserProfile');
 jest.mock('@/hooks/api/tagsCount/useFetchTagsCount');


### PR DESCRIPTION
- https://github.com/ai/nanoid#react
- nanoid에서 list key props로 사용하지말라고함. 대신에 index를 사용하는게 더 좋다고 함.
